### PR TITLE
Stack optmizations

### DIFF
--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -119,9 +119,9 @@ void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4], int add
     #endif
 }
 
-void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4]) {
+void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4], int add) {
     #if MLKEM_ETA2 == 2
-    cbd2(r, buf, 0);
+    cbd2(r, buf, add);
     #else
 #error "This implementation requires eta2 = 2"
     #endif

--- a/mlkem/cbd.c
+++ b/mlkem/cbd.c
@@ -53,7 +53,7 @@ static uint32_t load24_littleendian(const uint8_t x[3]) {
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *buf: pointer to input byte array
 **************************************************/
-static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4]) {
+static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4], int add) {
     unsigned int i, j;
     uint32_t t, d;
     int16_t a, b;
@@ -66,7 +66,10 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4]) {
         for (j = 0; j < 8; j++) {
             a = (d >> (4 * j + 0)) & 0x3;
             b = (d >> (4 * j + 2)) & 0x3;
-            r->coeffs[8 * i + j] = a - b;
+            if (!add) {
+                r->coeffs[8 * i + j] = 0;
+            }
+            r->coeffs[8 * i + j] += a - b;
         }
     }
 }
@@ -83,7 +86,7 @@ static void cbd2(poly *r, const uint8_t buf[2 * MLKEM_N / 4]) {
 *              - const uint8_t *buf: pointer to input byte array
 **************************************************/
 #if MLKEM_ETA1 == 3
-static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4]) {
+static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4], int add) {
     unsigned int i, j;
     uint32_t t, d;
     int16_t a, b;
@@ -97,17 +100,20 @@ static void cbd3(poly *r, const uint8_t buf[3 * MLKEM_N / 4]) {
         for (j = 0; j < 4; j++) {
             a = (d >> (6 * j + 0)) & 0x7;
             b = (d >> (6 * j + 3)) & 0x7;
-            r->coeffs[4 * i + j] = a - b;
+            if (!add) {
+                r->coeffs[4 * i + j] = 0;
+            }
+            r->coeffs[4 * i + j] += a - b;
         }
     }
 }
 #endif
 
-void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4]) {
+void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4], int add) {
     #if MLKEM_ETA1 == 2
-    cbd2(r, buf);
+    cbd2(r, buf, add);
     #elif MLKEM_ETA1 == 3
-    cbd3(r, buf);
+    cbd3(r, buf, add);
     #else
 #error "This implementation requires eta1 in {2,3}"
     #endif
@@ -115,7 +121,7 @@ void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4]) {
 
 void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4]) {
     #if MLKEM_ETA2 == 2
-    cbd2(r, buf);
+    cbd2(r, buf, 0);
     #else
 #error "This implementation requires eta2 = 2"
     #endif

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -10,6 +10,6 @@
 void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4], int add);
 
 #define poly_cbd_eta2 MLKEM_NAMESPACE(poly_cbd_eta2)
-void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4]);
+void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4], int add);
 
 #endif

--- a/mlkem/cbd.h
+++ b/mlkem/cbd.h
@@ -7,7 +7,7 @@
 #include "poly.h"
 
 #define poly_cbd_eta1 MLKEM_NAMESPACE(poly_cbd_eta1)
-void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4]);
+void poly_cbd_eta1(poly *r, const uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4], int add);
 
 #define poly_cbd_eta2 MLKEM_NAMESPACE(poly_cbd_eta2)
 void poly_cbd_eta2(poly *r, const uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4]);

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -9,35 +9,18 @@
 #include "ntt.h"
 #include "symmetric.h"
 #include "randombytes.h"
+#include "matacc.h"
 
 /*************************************************
-* Name:        pack_pk
-*
-* Description: Serialize the public key as concatenation of the
-*              serialized vector of polynomials pk
-*              and the public seed used to generate the matrix A.
-*
-* Arguments:   uint8_t *r: pointer to the output serialized public key
-*              polyvec *pk: pointer to the input public-key polyvec
-*              const uint8_t *seed: pointer to the input public seed
-**************************************************/
-static void pack_pk(uint8_t r[MLKEM_INDCPA_PUBLICKEYBYTES],
-                    polyvec *pk,
-                    const uint8_t seed[MLKEM_SYMBYTES]) {
-    polyvec_tobytes(r, pk);
-    memcpy(r + MLKEM_POLYVECBYTES, seed, MLKEM_SYMBYTES);
-}
-
-/*************************************************
-* Name:        unpack_pk
-*
-* Description: De-serialize public key from a byte array;
-*              approximate inverse of pack_pk
-*
-* Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
-*              - uint8_t *seed: pointer to output seed to generate matrix A
-*              - const uint8_t *packedpk: pointer to input serialized public key
-**************************************************/
+ * Name:        unpack_pk
+ *
+ * Description: De-serialize public key from a byte array;
+ *              approximate inverse of pack_pk
+ *
+ * Arguments:   - polyvec *pk: pointer to output public-key polynomial vector
+ *              - uint8_t *seed: pointer to output seed to generate matrix A
+ *              - const uint8_t *packedpk: pointer to input serialized public key
+ **************************************************/
 static void unpack_pk(polyvec *pk,
                       uint8_t seed[MLKEM_SYMBYTES],
                       const uint8_t packedpk[MLKEM_INDCPA_PUBLICKEYBYTES]) {
@@ -46,73 +29,73 @@ static void unpack_pk(polyvec *pk,
 }
 
 /*************************************************
-* Name:        pack_sk
-*
-* Description: Serialize the secret key
-*
-* Arguments:   - uint8_t *r: pointer to output serialized secret key
-*              - polyvec *sk: pointer to input vector of polynomials (secret key)
-**************************************************/
+ * Name:        pack_sk
+ *
+ * Description: Serialize the secret key
+ *
+ * Arguments:   - uint8_t *r: pointer to output serialized secret key
+ *              - polyvec *sk: pointer to input vector of polynomials (secret key)
+ **************************************************/
 static void pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], polyvec *sk) {
     polyvec_tobytes(r, sk);
 }
 
 /*************************************************
-* Name:        unpack_sk
-*
-* Description: De-serialize the secret key; inverse of pack_sk
-*
-* Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
-*              - const uint8_t *packedsk: pointer to input serialized secret key
-**************************************************/
+ * Name:        unpack_sk
+ *
+ * Description: De-serialize the secret key; inverse of pack_sk
+ *
+ * Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
+ *              - const uint8_t *packedsk: pointer to input serialized secret key
+ **************************************************/
 static void unpack_sk(polyvec *sk, const uint8_t packedsk[MLKEM_INDCPA_SECRETKEYBYTES]) {
     polyvec_frombytes(sk, packedsk);
 }
 
 /*************************************************
-* Name:        pack_ciphertext
-*
-* Description: Serialize the ciphertext as concatenation of the
-*              compressed and serialized vector of polynomials b
-*              and the compressed and serialized polynomial v
-*
-* Arguments:   uint8_t *r: pointer to the output serialized ciphertext
-*              poly *pk: pointer to the input vector of polynomials b
-*              poly *v: pointer to the input polynomial v
-**************************************************/
+ * Name:        pack_ciphertext
+ *
+ * Description: Serialize the ciphertext as concatenation of the
+ *              compressed and serialized vector of polynomials b
+ *              and the compressed and serialized polynomial v
+ *
+ * Arguments:   uint8_t *r: pointer to the output serialized ciphertext
+ *              poly *pk: pointer to the input vector of polynomials b
+ *              poly *v: pointer to the input polynomial v
+ **************************************************/
 static void pack_ciphertext(uint8_t r[MLKEM_INDCPA_BYTES], polyvec *b, poly *v) {
     polyvec_compress(r, b);
     poly_compress(r + MLKEM_POLYVECCOMPRESSEDBYTES, v);
 }
 
 /*************************************************
-* Name:        unpack_ciphertext
-*
-* Description: De-serialize and decompress ciphertext from a byte array;
-*              approximate inverse of pack_ciphertext
-*
-* Arguments:   - polyvec *b: pointer to the output vector of polynomials b
-*              - poly *v: pointer to the output polynomial v
-*              - const uint8_t *c: pointer to the input serialized ciphertext
-**************************************************/
+ * Name:        unpack_ciphertext
+ *
+ * Description: De-serialize and decompress ciphertext from a byte array;
+ *              approximate inverse of pack_ciphertext
+ *
+ * Arguments:   - polyvec *b: pointer to the output vector of polynomials b
+ *              - poly *v: pointer to the output polynomial v
+ *              - const uint8_t *c: pointer to the input serialized ciphertext
+ **************************************************/
 static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[MLKEM_INDCPA_BYTES]) {
     polyvec_decompress(b, c);
     poly_decompress(v, c + MLKEM_POLYVECCOMPRESSEDBYTES);
 }
 
 /*************************************************
-* Name:        rej_uniform
-*
-* Description: Run rejection sampling on uniform random bytes to generate
-*              uniform random integers mod q
-*
-* Arguments:   - int16_t *r: pointer to output buffer
-*              - unsigned int len: requested number of 16-bit integers (uniform mod q)
-*              - const uint8_t *buf: pointer to input buffer (assumed to be uniformly random bytes)
-*              - unsigned int buflen: length of input buffer in bytes
-*
-* Returns number of sampled 16-bit integers (at most len)
-**************************************************/
+ * Name:        rej_uniform
+ *
+ * Description: Run rejection sampling on uniform random bytes to generate
+ *              uniform random integers mod q
+ *
+ * Arguments:   - int16_t *r: pointer to output buffer
+ *              - unsigned int len: requested number of 16-bit integers (uniform mod q)
+ *              - const uint8_t *buf: pointer to input buffer (assumed to be uniformly random bytes)
+ *              - unsigned int buflen: length of input buffer in bytes
+ *
+ * Returns number of sampled 16-bit integers (at most len)
+ **************************************************/
 static unsigned int rej_uniform(int16_t *r,
                                 unsigned int len,
                                 const uint8_t *buf,
@@ -137,22 +120,22 @@ static unsigned int rej_uniform(int16_t *r,
     return ctr;
 }
 
-#define gen_a(A,B)  gen_matrix(A,B,0)
-#define gen_at(A,B) gen_matrix(A,B,1)
+#define gen_a(A, B) gen_matrix(A, B, 0)
+#define gen_at(A, B) gen_matrix(A, B, 1)
 
 /*************************************************
-* Name:        gen_matrix
-*
-* Description: Deterministically generate matrix A (or the transpose of A)
-*              from a seed. Entries of the matrix are polynomials that look
-*              uniformly random. Performs rejection sampling on output of
-*              a XOF
-*
-* Arguments:   - polyvec *a: pointer to ouptput matrix A
-*              - const uint8_t *seed: pointer to input seed
-*              - int transposed: boolean deciding whether A or A^T is generated
-**************************************************/
-#define GEN_MATRIX_NBLOCKS ((12*MLKEM_N/8*(1 << 12)/MLKEM_Q + XOF_BLOCKBYTES)/XOF_BLOCKBYTES)
+ * Name:        gen_matrix
+ *
+ * Description: Deterministically generate matrix A (or the transpose of A)
+ *              from a seed. Entries of the matrix are polynomials that look
+ *              uniformly random. Performs rejection sampling on output of
+ *              a XOF
+ *
+ * Arguments:   - polyvec *a: pointer to ouptput matrix A
+ *              - const uint8_t *seed: pointer to input seed
+ *              - int transposed: boolean deciding whether A or A^T is generated
+ **************************************************/
+#define GEN_MATRIX_NBLOCKS ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + XOF_BLOCKBYTES) / XOF_BLOCKBYTES)
 // Not static for benchmarking
 void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed) {
     unsigned int ctr, i, j, k;
@@ -186,18 +169,18 @@ void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed) 
 }
 
 /*************************************************
-* Name:        indcpa_keypair_derand
-*
-* Description: Generates public and private key for the CPA-secure
-*              public-key encryption scheme underlying Mlkem
-*
-* Arguments:   - uint8_t *pk: pointer to output public key
-*                             (of length MLKEM_INDCPA_PUBLICKEYBYTES bytes)
-*              - uint8_t *sk: pointer to output private key
-*                             (of length MLKEM_INDCPA_SECRETKEYBYTES bytes)
-*              - const uint8_t *coins: pointer to input randomness
-*                             (of length MLKEM_SYMBYTES bytes)
-**************************************************/
+ * Name:        indcpa_keypair_derand
+ *
+ * Description: Generates public and private key for the CPA-secure
+ *              public-key encryption scheme underlying Mlkem
+ *
+ * Arguments:   - uint8_t *pk: pointer to output public key
+ *                             (of length MLKEM_INDCPA_PUBLICKEYBYTES bytes)
+ *              - uint8_t *sk: pointer to output private key
+ *                             (of length MLKEM_INDCPA_SECRETKEYBYTES bytes)
+ *              - const uint8_t *coins: pointer to input randomness
+ *                             (of length MLKEM_SYMBYTES bytes)
+ **************************************************/
 void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                            uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES],
                            const uint8_t coins[MLKEM_SYMBYTES]) {
@@ -206,51 +189,49 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
     const uint8_t *publicseed = buf;
     const uint8_t *noiseseed = buf + MLKEM_SYMBYTES;
     uint8_t nonce = 0;
-    polyvec a[MLKEM_K], e, pkpv, skpv;
+    polyvec skpv;
+    poly pkp;
 
     hash_g(buf, coins, MLKEM_SYMBYTES);
-
-    gen_a(a, publicseed);
 
     for (i = 0; i < MLKEM_K; i++) {
         poly_getnoise_eta1(&skpv.vec[i], noiseseed, nonce++);
     }
-    for (i = 0; i < MLKEM_K; i++) {
-        poly_getnoise_eta1(&e.vec[i], noiseseed, nonce++);
-    }
 
     polyvec_ntt(&skpv);
-    polyvec_ntt(&e);
 
     // matrix-vector multiplication
     for (i = 0; i < MLKEM_K; i++) {
-        polyvec_basemul_acc_montgomery(&pkpv.vec[i], &a[i], &skpv);
-        poly_tomont(&pkpv.vec[i]);
+        matacc(&pkp, &skpv, i, publicseed, 0);
+
+        poly_invntt_tomont(&pkp);
+        poly_addnoise_eta1(&pkp, noiseseed, nonce++);
+        poly_ntt(&pkp);
+        poly_reduce(&pkp);
+
+        poly_tobytes(pk + i * MLKEM_POLYBYTES, &pkp);
     }
 
-    polyvec_add(&pkpv, &pkpv, &e);
-    polyvec_reduce(&pkpv);
-
     pack_sk(sk, &skpv);
-    pack_pk(pk, &pkpv, publicseed);
+    memcpy(pk + MLKEM_POLYVECBYTES, publicseed, MLKEM_SYMBYTES);
 }
 
 /*************************************************
-* Name:        indcpa_enc
-*
-* Description: Encryption function of the CPA-secure
-*              public-key encryption scheme underlying Mlkem.
-*
-* Arguments:   - uint8_t *c: pointer to output ciphertext
-*                            (of length MLKEM_INDCPA_BYTES bytes)
-*              - const uint8_t *m: pointer to input message
-*                                  (of length MLKEM_INDCPA_MSGBYTES bytes)
-*              - const uint8_t *pk: pointer to input public key
-*                                   (of length MLKEM_INDCPA_PUBLICKEYBYTES)
-*              - const uint8_t *coins: pointer to input random coins used as seed
-*                                      (of length MLKEM_SYMBYTES) to deterministically
-*                                      generate all randomness
-**************************************************/
+ * Name:        indcpa_enc
+ *
+ * Description: Encryption function of the CPA-secure
+ *              public-key encryption scheme underlying Mlkem.
+ *
+ * Arguments:   - uint8_t *c: pointer to output ciphertext
+ *                            (of length MLKEM_INDCPA_BYTES bytes)
+ *              - const uint8_t *m: pointer to input message
+ *                                  (of length MLKEM_INDCPA_MSGBYTES bytes)
+ *              - const uint8_t *pk: pointer to input public key
+ *                                   (of length MLKEM_INDCPA_PUBLICKEYBYTES)
+ *              - const uint8_t *coins: pointer to input random coins used as seed
+ *                                      (of length MLKEM_SYMBYTES) to deterministically
+ *                                      generate all randomness
+ **************************************************/
 void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
@@ -295,18 +276,18 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
 }
 
 /*************************************************
-* Name:        indcpa_dec
-*
-* Description: Decryption function of the CPA-secure
-*              public-key encryption scheme underlying Mlkem.
-*
-* Arguments:   - uint8_t *m: pointer to output decrypted message
-*                            (of length MLKEM_INDCPA_MSGBYTES)
-*              - const uint8_t *c: pointer to input ciphertext
-*                                  (of length MLKEM_INDCPA_BYTES)
-*              - const uint8_t *sk: pointer to input secret key
-*                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
-**************************************************/
+ * Name:        indcpa_dec
+ *
+ * Description: Decryption function of the CPA-secure
+ *              public-key encryption scheme underlying Mlkem.
+ *
+ * Arguments:   - uint8_t *m: pointer to output decrypted message
+ *                            (of length MLKEM_INDCPA_MSGBYTES)
+ *              - const uint8_t *c: pointer to input ciphertext
+ *                                  (of length MLKEM_INDCPA_BYTES)
+ *              - const uint8_t *sk: pointer to input secret key
+ *                                   (of length MLKEM_INDCPA_SECRETKEYBYTES)
+ **************************************************/
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t sk[MLKEM_INDCPA_SECRETKEYBYTES]) {

--- a/mlkem/indcpa.c
+++ b/mlkem/indcpa.c
@@ -12,130 +12,6 @@
 #include "matacc.h"
 
 /*************************************************
- * Name:        pack_sk
- *
- * Description: Serialize the secret key
- *
- * Arguments:   - uint8_t *r: pointer to output serialized secret key
- *              - polyvec *sk: pointer to input vector of polynomials (secret key)
- **************************************************/
-static void pack_sk(uint8_t r[MLKEM_INDCPA_SECRETKEYBYTES], polyvec *sk) {
-    polyvec_tobytes(r, sk);
-}
-
-/*************************************************
- * Name:        unpack_sk
- *
- * Description: De-serialize the secret key; inverse of pack_sk
- *
- * Arguments:   - polyvec *sk: pointer to output vector of polynomials (secret key)
- *              - const uint8_t *packedsk: pointer to input serialized secret key
- **************************************************/
-static void unpack_sk(polyvec *sk, const uint8_t packedsk[MLKEM_INDCPA_SECRETKEYBYTES]) {
-    polyvec_frombytes(sk, packedsk);
-}
-
-/*************************************************
- * Name:        unpack_ciphertext
- *
- * Description: De-serialize and decompress ciphertext from a byte array;
- *              approximate inverse of pack_ciphertext
- *
- * Arguments:   - polyvec *b: pointer to the output vector of polynomials b
- *              - poly *v: pointer to the output polynomial v
- *              - const uint8_t *c: pointer to the input serialized ciphertext
- **************************************************/
-static void unpack_ciphertext(polyvec *b, poly *v, const uint8_t c[MLKEM_INDCPA_BYTES]) {
-    polyvec_decompress(b, c);
-    poly_decompress(v, c + MLKEM_POLYVECCOMPRESSEDBYTES);
-}
-
-/*************************************************
- * Name:        rej_uniform
- *
- * Description: Run rejection sampling on uniform random bytes to generate
- *              uniform random integers mod q
- *
- * Arguments:   - int16_t *r: pointer to output buffer
- *              - unsigned int len: requested number of 16-bit integers (uniform mod q)
- *              - const uint8_t *buf: pointer to input buffer (assumed to be uniformly random bytes)
- *              - unsigned int buflen: length of input buffer in bytes
- *
- * Returns number of sampled 16-bit integers (at most len)
- **************************************************/
-static unsigned int rej_uniform(int16_t *r,
-                                unsigned int len,
-                                const uint8_t *buf,
-                                unsigned int buflen) {
-    unsigned int ctr, pos;
-    uint16_t val0, val1;
-
-    ctr = pos = 0;
-    while (ctr < len && pos + 3 <= buflen) {
-        val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
-        val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
-        pos += 3;
-
-        if (val0 < MLKEM_Q) {
-            r[ctr++] = val0;
-        }
-        if (ctr < len && val1 < MLKEM_Q) {
-            r[ctr++] = val1;
-        }
-    }
-
-    return ctr;
-}
-
-#define gen_a(A, B) gen_matrix(A, B, 0)
-#define gen_at(A, B) gen_matrix(A, B, 1)
-
-/*************************************************
- * Name:        gen_matrix
- *
- * Description: Deterministically generate matrix A (or the transpose of A)
- *              from a seed. Entries of the matrix are polynomials that look
- *              uniformly random. Performs rejection sampling on output of
- *              a XOF
- *
- * Arguments:   - polyvec *a: pointer to ouptput matrix A
- *              - const uint8_t *seed: pointer to input seed
- *              - int transposed: boolean deciding whether A or A^T is generated
- **************************************************/
-#define GEN_MATRIX_NBLOCKS ((12 * MLKEM_N / 8 * (1 << 12) / MLKEM_Q + XOF_BLOCKBYTES) / XOF_BLOCKBYTES)
-// Not static for benchmarking
-void gen_matrix(polyvec *a, const uint8_t seed[MLKEM_SYMBYTES], int transposed) {
-    unsigned int ctr, i, j, k;
-    unsigned int buflen, off;
-    uint8_t buf[GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES + 2];
-    xof_state state;
-
-    for (i = 0; i < MLKEM_K; i++) {
-        for (j = 0; j < MLKEM_K; j++) {
-            if (transposed) {
-                xof_absorb(&state, seed, i, j);
-            } else {
-                xof_absorb(&state, seed, j, i);
-            }
-
-            xof_squeezeblocks(buf, GEN_MATRIX_NBLOCKS, &state);
-            buflen = GEN_MATRIX_NBLOCKS * XOF_BLOCKBYTES;
-            ctr = rej_uniform(a[i].vec[j].coeffs, MLKEM_N, buf, buflen);
-
-            while (ctr < MLKEM_N) {
-                off = buflen % 3;
-                for (k = 0; k < off; k++) {
-                    buf[k] = buf[buflen - off + k];
-                }
-                xof_squeezeblocks(buf + off, 1, &state);
-                buflen = off + XOF_BLOCKBYTES;
-                ctr += rej_uniform(a[i].vec[j].coeffs + ctr, MLKEM_N - ctr, buf, buflen);
-            }
-        }
-    }
-}
-
-/*************************************************
  * Name:        indcpa_keypair_derand
  *
  * Description: Generates public and private key for the CPA-secure
@@ -179,7 +55,7 @@ void indcpa_keypair_derand(uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
         poly_tobytes(pk + i * MLKEM_POLYBYTES, &pkp);
     }
 
-    pack_sk(sk, &skpv);
+    polyvec_tobytes(sk, &skpv);
     memcpy(pk + MLKEM_POLYVECBYTES, publicseed, MLKEM_SYMBYTES);
 }
 

--- a/mlkem/indcpa.h
+++ b/mlkem/indcpa.h
@@ -20,6 +20,12 @@ void indcpa_enc(uint8_t c[MLKEM_INDCPA_BYTES],
                 const uint8_t pk[MLKEM_INDCPA_PUBLICKEYBYTES],
                 const uint8_t coins[MLKEM_SYMBYTES]);
 
+#define indcpa_enc_cmp MLKEM_NAMESPACE(indcpa_enc_cmp)
+unsigned char indcpa_enc_cmp(const unsigned char *ct,
+                             const unsigned char *m,
+                             const unsigned char *pk,
+                             const unsigned char *coins);
+
 #define indcpa_dec MLKEM_NAMESPACE(indcpa_dec)
 void indcpa_dec(uint8_t m[MLKEM_INDCPA_MSGBYTES],
                 const uint8_t c[MLKEM_INDCPA_BYTES],

--- a/mlkem/kem.c
+++ b/mlkem/kem.c
@@ -137,33 +137,6 @@ int crypto_kem_enc(uint8_t *ct,
 int crypto_kem_dec(uint8_t *ss,
                    const uint8_t *ct,
                    const uint8_t *sk) {
-    #if 0
-    int fail;
-    uint8_t buf[2 * MLKEM_SYMBYTES];
-    /* Will contain key, coins */
-    uint8_t kr[2 * MLKEM_SYMBYTES];
-    uint8_t cmp[MLKEM_CIPHERTEXTBYTES + MLKEM_SYMBYTES];
-    const uint8_t *pk = sk + MLKEM_INDCPA_SECRETKEYBYTES;
-
-    indcpa_dec(buf, ct, sk);
-
-    /* Multitarget countermeasure for coins + contributory KEM */
-    memcpy(buf + MLKEM_SYMBYTES, sk + MLKEM_SECRETKEYBYTES - 2 * MLKEM_SYMBYTES, MLKEM_SYMBYTES);
-    hash_g(kr, buf, 2 * MLKEM_SYMBYTES);
-
-    /* coins are in kr+MLKEM_SYMBYTES */
-    indcpa_enc(cmp, buf, pk, kr + MLKEM_SYMBYTES);
-
-    fail = verify(ct, cmp, MLKEM_CIPHERTEXTBYTES);
-
-    /* Compute rejection key */
-    rkprf(ss, sk + MLKEM_SECRETKEYBYTES - MLKEM_SYMBYTES, ct);
-
-    /* Copy true key to return buffer if fail is false */
-    cmov(ss, kr, MLKEM_SYMBYTES, !fail);
-
-    #else
-
     int fail;
     uint8_t buf[2 * MLKEM_SYMBYTES];
     /* Will contain key, coins */
@@ -184,8 +157,6 @@ int crypto_kem_dec(uint8_t *ss,
 
     /* Copy true key to return buffer if fail is false */
     cmov(ss, kr, MLKEM_SYMBYTES, (uint8_t) (1 - fail));
-
-    #endif
 
     return 0;
 }

--- a/mlkem/matacc.c
+++ b/mlkem/matacc.c
@@ -1,0 +1,85 @@
+#include "ntt.h"
+#include "poly.h"
+#include "polyvec.h"
+#include "symmetric.h"
+#include "matacc.h"
+
+static void doublebasemul(int16_t r[4], const int16_t b[4], const int16_t a[4], int k, int add) {
+    if (!add) {
+        basemul(r, a, b, zetas[64 + k]);
+        basemul(&r[2], &a[2], &b[2], -zetas[64 + k]);
+    } else {
+        basemul_acc(r, a, b, zetas[64 + k]);
+        basemul_acc(&r[2], &a[2], &b[2], -zetas[64 + k]);
+    }
+}
+
+static void matacc_inner(poly *r, const poly *b, unsigned char i, unsigned char j, const unsigned char *seed, int transposed, int add) {
+    xof_state state;
+    unsigned int ctr, ctr2;
+    int16_t ax[4];
+    uint8_t buf[XOF_BLOCKBYTES];
+
+    if (transposed) {
+        xof_absorb(&state, seed, i, j);
+    } else {
+        xof_absorb(&state, seed, j, i);
+    }
+
+    ctr = 0;
+    ctr2 = 0;
+    do {
+        xof_squeezeblocks(buf, 1, &state);
+        unsigned int pos;
+        uint16_t val0, val1;
+
+        pos = 0;
+        while (ctr < MLKEM_N && pos + 3 <= XOF_BLOCKBYTES) {
+            val0 = ((buf[pos + 0] >> 0) | ((uint16_t)buf[pos + 1] << 8)) & 0xFFF;
+            val1 = ((buf[pos + 1] >> 4) | ((uint16_t)buf[pos + 2] << 4)) & 0xFFF;
+            pos += 3;
+
+            if (val0 < MLKEM_Q) {
+                ax[ctr2] = val0;
+                ctr++;
+                ctr2++;
+            }
+            if (ctr2 == 4) {
+                doublebasemul(r->coeffs + ctr - 4, b->coeffs + ctr - 4, ax, (ctr - 4) / 4, add);
+                ctr2 = 0;
+            }
+
+            if (ctr < MLKEM_N && val1 < MLKEM_Q) {
+                ax[ctr2] = val1;
+                ctr++;
+                ctr2++;
+            }
+            if (ctr2 == 4) {
+                doublebasemul(r->coeffs + ctr - 4, b->coeffs + ctr - 4, ax, (ctr - 4) / 4, add);
+                ctr2 = 0;
+            }
+        }
+
+    } while (ctr < MLKEM_N);
+}
+
+/*************************************************
+ * Name:        matacc
+ *
+ * Description: Multiplies a row of A or A^T, generated on-the-fly,
+ *              with a vector of polynomials and accumulates into the result.
+ *
+ * Arguments:   - poly *r:                    pointer to output polynomial to accumulate in
+ *              - polyvec *b:                 pointer to input vector of polynomials to multiply with
+ *              - unsigned char i:            byte to indicate the index < MLKEM_K of the row of A or A^T
+ *              - const unsigned char *seed:  pointer to the public seed used to generate A
+ *              - int transposed:             boolean indicating whether A or A^T is generated
+ **************************************************/
+void matacc(poly *r, const polyvec *b, unsigned char i, const unsigned char *seed, int transposed) {
+    int j = 0;
+    matacc_inner(r, &b->vec[j], i, j, seed, transposed, 0);
+
+    for (j = 1; j < MLKEM_K; j++) {
+        matacc_inner(r, &b->vec[j], i, j, seed, transposed, 1);
+    }
+}

--- a/mlkem/matacc.c
+++ b/mlkem/matacc.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #include "ntt.h"
 #include "poly.h"
 #include "polyvec.h"
@@ -14,6 +15,20 @@ static void doublebasemul(int16_t r[4], const int16_t b[4], const int16_t a[4], 
     }
 }
 
+/*************************************************
+ * Name:        matacc_inner
+ *
+ * Description: Multiplies a polynomial of A or A^T, generated on-the-fly,
+ *              with a polynomials polynomial and accumulates into the result.
+ *
+ * Arguments:   - poly *r:                    pointer to output polynomial to accumulate in
+ *              - poly *b:                    pointer to input polynomial to multiply with
+ *              - unsigned char i:            byte to indicate the index < KYBER_K of the row of A or A^T
+ *              - unsigned char j:            byte to indicate the index < KYBER_K of the column of A or A^T
+ *              - const unsigned char *seed:  pointer to the public seed used to generate A
+ *              - int transposed:             boolean indicating whether A or A^T is generated
+ *              - int add:                    boolean indicating whether this is accumulating into r (add=0 will initialize r to 0)
+ **************************************************/
 static void matacc_inner(poly *r, const poly *b, unsigned char i, unsigned char j, const unsigned char *seed, int transposed, int add) {
     xof_state state;
     unsigned int ctr, ctr2;

--- a/mlkem/matacc.h
+++ b/mlkem/matacc.h
@@ -1,6 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
 #ifndef MATACC_H
 #define MATACC_H
 
+#include "params.h"
+
+#define matacc MLKEM_NAMESPACE(matacc)
 void matacc(poly *r, const polyvec *b, unsigned char i, const unsigned char *seed, int transposed);
 
 #endif

--- a/mlkem/matacc.h
+++ b/mlkem/matacc.h
@@ -1,0 +1,6 @@
+#ifndef MATACC_H
+#define MATACC_H
+
+void matacc(poly *r, const polyvec *b, unsigned char i, const unsigned char *seed, int transposed);
+
+#endif

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -145,3 +145,23 @@ void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta)
     r[1]  = fqmul(a[0], b[1]);
     r[1] += fqmul(a[1], b[0]);
 }
+
+/*************************************************
+* Name:        basemul_acc
+*
+* Description: Multiplication of polynomials in Zq[X]/(X^2-zeta)
+*              used for multiplication of elements in Rq in NTT domain.
+*              Accumulating version
+*
+* Arguments:   - int16_t r[2]: pointer to the output polynomial
+*              - const int16_t a[2]: pointer to the first factor
+*              - const int16_t b[2]: pointer to the second factor
+*              - int16_t zeta: integer defining the reduction polynomial
+**************************************************/
+void basemul_acc(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta) {
+    int16_t t  = fqmul(a[1], b[1]);
+    r[0]  += fqmul(t, zeta);
+    r[0]  += fqmul(a[0], b[0]);
+    r[1]  += fqmul(a[0], b[1]);
+    r[1]  += fqmul(a[1], b[0]);
+}

--- a/mlkem/ntt.c
+++ b/mlkem/ntt.c
@@ -139,11 +139,17 @@ void invntt(int16_t r[256]) {
 *              - int16_t zeta: integer defining the reduction polynomial
 **************************************************/
 void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta) {
-    r[0]  = fqmul(a[1], b[1]);
+    // copy to allow overlap between r and a,b
+    int16_t a0 = a[0];
+    int16_t a1 = a[1];
+    int16_t b0 = b[0];
+    int16_t b1 = b[1];
+
+    r[0]  = fqmul(a1, b1);
     r[0]  = fqmul(r[0], zeta);
-    r[0] += fqmul(a[0], b[0]);
-    r[1]  = fqmul(a[0], b[1]);
-    r[1] += fqmul(a[1], b[0]);
+    r[0] += fqmul(a0, b0);
+    r[1]  = fqmul(a0, b1);
+    r[1] += fqmul(a1, b0);
 }
 
 /*************************************************
@@ -159,9 +165,15 @@ void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta)
 *              - int16_t zeta: integer defining the reduction polynomial
 **************************************************/
 void basemul_acc(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta) {
-    int16_t t  = fqmul(a[1], b[1]);
+    // copy to allow overlap between r and a,b
+    int16_t a0 = a[0];
+    int16_t a1 = a[1];
+    int16_t b0 = b[0];
+    int16_t b1 = b[1];
+
+    int16_t t  = fqmul(a1, b1);
     r[0]  += fqmul(t, zeta);
-    r[0]  += fqmul(a[0], b[0]);
-    r[1]  += fqmul(a[0], b[1]);
-    r[1]  += fqmul(a[1], b[0]);
+    r[0]  += fqmul(a0, b0);
+    r[1]  += fqmul(a0, b1);
+    r[1]  += fqmul(a1, b0);
 }

--- a/mlkem/ntt.h
+++ b/mlkem/ntt.h
@@ -17,4 +17,7 @@ void invntt(int16_t poly[256]);
 #define basemul MLKEM_NAMESPACE(basemul)
 void basemul(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
 
+#define basemul_acc MLKEM_NAMESPACE(basemul_acc)
+void basemul_acc(int16_t r[2], const int16_t a[2], const int16_t b[2], int16_t zeta);
+
 #endif

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -112,6 +112,75 @@ void poly_decompress(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES]) {
 }
 
 /*************************************************
+* Name:        poly_packcompress
+*
+* Description: Serialization and subsequent compression of a polynomial of a polyvec,
+*              writes to a byte string representation of the whole polyvec.
+*              Used to compress a polyvec one poly at a time in a loop.
+*
+* Arguments:   - unsigned char *r:  pointer to output byte string representation of a polyvec (of length MLKEM_POLYVECCOMPRESSEDBYTES)
+*              - const poly *a:     pointer to input polynomial
+*              - int i:             index of to be serialized polynomial in serialized polyec
+**************************************************/
+void poly_packcompress(unsigned char *r, poly *a, int i) {
+    int j, k;
+    uint64_t d0;
+
+    #if (MLKEM_POLYVECCOMPRESSEDBYTES == (MLKEM_K * 352))
+    uint16_t t[8];
+
+    for (j = 0; j < MLKEM_N / 8; j++) {
+        for (k = 0; k < 8; k++) {
+            t[k]  = a->coeffs[8 * j + k];
+            t[k] += ((int16_t)t[k] >> 15) & MLKEM_Q;
+            /*      t[k]  = ((((uint32_t)t[k] << 11) + MLKEM_Q/2)/MLKEM_Q) & 0x7ff; */
+            d0 = t[k];
+            d0 <<= 11;
+            d0 += 1664;
+            d0 *= 645084;
+            d0 >>= 31;
+            t[k] = d0 & 0x7ff;
+        }
+
+        r[352 * i + 11 * j + 0] =  t[0] & 0xff;
+        r[352 * i + 11 * j + 1] = (t[0] >>  8) | ((t[1] & 0x1f) << 3);
+        r[352 * i + 11 * j + 2] = (t[1] >>  5) | ((t[2] & 0x03) << 6);
+        r[352 * i + 11 * j + 3] = (t[2] >>  2) & 0xff;
+        r[352 * i + 11 * j + 4] = (t[2] >> 10) | ((t[3] & 0x7f) << 1);
+        r[352 * i + 11 * j + 5] = (t[3] >>  7) | ((t[4] & 0x0f) << 4);
+        r[352 * i + 11 * j + 6] = (t[4] >>  4) | ((t[5] & 0x01) << 7);
+        r[352 * i + 11 * j + 7] = (t[5] >>  1) & 0xff;
+        r[352 * i + 11 * j + 8] = (t[5] >>  9) | ((t[6] & 0x3f) << 2);
+        r[352 * i + 11 * j + 9] = (t[6] >>  6) | ((t[7] & 0x07) << 5);
+        r[352 * i + 11 * j + 10] = (t[7] >>  3);
+    }
+    #elif (MLKEM_POLYVECCOMPRESSEDBYTES == (MLKEM_K * 320))
+    uint16_t t[4];
+
+    for (j = 0; j < MLKEM_N / 4; j++) {
+        for (k = 0; k < 4; k++) {
+            t[k]  = a->coeffs[4 * j + k];
+            t[k] += ((int16_t)t[k] >> 15) & MLKEM_Q;
+            /*      t[k]  = ((((uint32_t)t[k] << 10) + MLKEM_Q/2)/ MLKEM_Q) & 0x3ff; */
+            d0 = t[k];
+            d0 <<= 10;
+            d0 += 1665;
+            d0 *= 1290167;
+            d0 >>= 32;
+            t[k] = d0 & 0x3ff;
+        }
+        r[320 * i + 5 * j + 0] =   t[0] & 0xff;
+        r[320 * i + 5 * j + 1] =  (t[0] >>  8) | ((t[1] & 0x3f) << 2);
+        r[320 * i + 5 * j + 2] = ((t[1] >>  6) | ((t[2] & 0x0f) << 4)) & 0xff;
+        r[320 * i + 5 * j + 3] = ((t[2] >>  4) | ((t[3] & 0x03) << 6)) & 0xff;
+        r[320 * i + 5 * j + 4] =  (t[3] >>  2) & 0xff;
+    }
+    #else
+#error "MLKEM_POLYVECCOMPRESSEDBYTES needs to in (MLKEM_K * {352, 320})"
+    #endif
+}
+
+/*************************************************
 * Name:        poly_tobytes
 *
 * Description: Serialization of a polynomial
@@ -228,21 +297,23 @@ void poly_noise_eta1(poly *r, const unsigned char *seed, unsigned char nonce, in
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta2
+* Name:        poly_noise_eta2
 *
 * Description: Sample a polynomial deterministically from a seed and a nonce,
 *              with output polynomial close to centered binomial distribution
 *              with parameter MLKEM_ETA2
+*              Conditionally accumulate.
 *
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *seed: pointer to input seed
 *                                     (of length MLKEM_SYMBYTES bytes)
 *              - uint8_t nonce: one-byte input nonce
+*              - int add: flag to conditionally accumulate into r if add != 0
 **************************************************/
-void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce) {
+void poly_noise_eta2(poly *r, const unsigned char *seed, unsigned char nonce, int add) {
     uint8_t buf[MLKEM_ETA2 * MLKEM_N / 4];
     prf(buf, sizeof(buf), seed, nonce);
-    poly_cbd_eta2(r, buf);
+    poly_cbd_eta2(r, buf, add);
 }
 
 /*************************************************
@@ -281,11 +352,18 @@ void poly_invntt_tomont(poly *r) {
 *              - const poly *a: pointer to first input polynomial
 *              - const poly *b: pointer to second input polynomial
 **************************************************/
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b) {
+void poly_basemul_montgomery(poly *r, const poly *a, const poly *b, int add) {
     unsigned int i;
-    for (i = 0; i < MLKEM_N / 4; i++) {
-        basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i], zetas[64 + i]);
-        basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2], -zetas[64 + i]);
+    if (!add) {
+        for (i = 0; i < MLKEM_N / 4; i++) {
+            basemul(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i], zetas[64 + i]);
+            basemul(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2], -zetas[64 + i]);
+        }
+    } else {
+        for (i = 0; i < MLKEM_N / 4; i++) {
+            basemul_acc(&r->coeffs[4 * i], &a->coeffs[4 * i], &b->coeffs[4 * i], zetas[64 + i]);
+            basemul_acc(&r->coeffs[4 * i + 2], &a->coeffs[4 * i + 2], &b->coeffs[4 * i + 2], -zetas[64 + i]);
+        }
     }
 }
 

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -207,21 +207,24 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *a) {
 }
 
 /*************************************************
-* Name:        poly_getnoise_eta1
+* Name:        poly_noise_eta1
 *
 * Description: Sample a polynomial deterministically from a seed and a nonce,
 *              with output polynomial close to centered binomial distribution
-*              with parameter MLKEM_ETA1
+*              with parameter MLKEM_ETA1.
+*              Conditionally accumulate.
 *
 * Arguments:   - poly *r: pointer to output polynomial
 *              - const uint8_t *seed: pointer to input seed
 *                                     (of length MLKEM_SYMBYTES bytes)
 *              - uint8_t nonce: one-byte input nonce
+*              - int add: flag to conditionally accumulate into r if add != 0
 **************************************************/
-void poly_getnoise_eta1(poly *r, const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce) {
-    uint8_t buf[MLKEM_ETA1 * MLKEM_N / 4];
-    prf(buf, sizeof(buf), seed, nonce);
-    poly_cbd_eta1(r, buf);
+void poly_noise_eta1(poly *r, const unsigned char *seed, unsigned char nonce, int add) {
+    unsigned char buf[MLKEM_ETA1 * MLKEM_N / 4];
+
+    prf(buf, MLKEM_ETA1 * MLKEM_N / 4, seed, nonce);
+    poly_cbd_eta1(r, buf, add);
 }
 
 /*************************************************
@@ -346,5 +349,12 @@ void poly_sub(poly *r, const poly *a, const poly *b) {
     unsigned int i;
     for (i = 0; i < MLKEM_N; i++) {
         r->coeffs[i] = a->coeffs[i] - b->coeffs[i];
+    }
+}
+
+void poly_frommont(poly *r) {
+    unsigned int i;
+    for (i = 0; i < MLKEM_N; i++) {
+        r->coeffs[i] = montgomery_reduce(r->coeffs[i]);
     }
 }

--- a/mlkem/poly.c
+++ b/mlkem/poly.c
@@ -629,10 +629,3 @@ void poly_sub(poly *r, const poly *a, const poly *b) {
         r->coeffs[i] = a->coeffs[i] - b->coeffs[i];
     }
 }
-
-void poly_frommont(poly *r) {
-    unsigned int i;
-    for (i = 0; i < MLKEM_N; i++) {
-        r->coeffs[i] = montgomery_reduce(r->coeffs[i]);
-    }
-}

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -8,6 +8,12 @@
 #define poly_getnoise_eta1(p, seed, nonce) poly_noise_eta1(p, seed, nonce, 0)
 #define poly_addnoise_eta1(p, seed, nonce) poly_noise_eta1(p, seed, nonce, 1)
 
+#define poly_getnoise_eta2(p, seed, nonce) poly_noise_eta2(p, seed, nonce, 0)
+#define poly_addnoise_eta2(p, seed, nonce) poly_noise_eta2(p, seed, nonce, 1)
+
+#define poly_basemul(r, a, b) poly_basemul_montgomery(r, a, b, 0)
+#define poly_basemul_acc(r, a, b) poly_basemul_montgomery(r, a, b, 1)
+
 /*
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
  * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]
@@ -26,6 +32,9 @@ void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a);
 #define poly_frombytes MLKEM_NAMESPACE(poly_frombytes)
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES]);
 
+#define poly_packcompress MLKEM_NAMESPACE(poly_packcompress)
+void poly_packcompress(unsigned char *r, poly *a, int i);
+
 #define poly_frommsg MLKEM_NAMESPACE(poly_frommsg)
 void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES]);
 #define poly_tomsg MLKEM_NAMESPACE(poly_tomsg)
@@ -34,15 +43,17 @@ void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *r);
 #define poly_noise_eta1 MLKEM_NAMESPACE(poly_noise_eta1)
 void poly_noise_eta1(poly *r, const unsigned char *seed, unsigned char nonce, int add);
 
-#define poly_getnoise_eta2 MLKEM_NAMESPACE(poly_getnoise_eta2)
-void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce);
+#define poly_noise_eta2 MLKEM_NAMESPACE(poly_noise_eta2)
+void poly_noise_eta2(poly *r, const unsigned char *seed, unsigned char nonce, int add);
 
 #define poly_ntt MLKEM_NAMESPACE(poly_ntt)
 void poly_ntt(poly *r);
 #define poly_invntt_tomont MLKEM_NAMESPACE(poly_invntt_tomont)
 void poly_invntt_tomont(poly *r);
+
 #define poly_basemul_montgomery MLKEM_NAMESPACE(poly_basemul_montgomery)
-void poly_basemul_montgomery(poly *r, const poly *a, const poly *b);
+void poly_basemul_montgomery(poly *r, const poly *a, const poly *b, int add);
+
 #define poly_tomont MLKEM_NAMESPACE(poly_tomont)
 void poly_tomont(poly *r);
 

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -78,6 +78,4 @@ void poly_add(poly *r, const poly *a, const poly *b);
 #define poly_sub MLKEM_NAMESPACE(poly_sub)
 void poly_sub(poly *r, const poly *a, const poly *b);
 
-void poly_frommont(poly *r);
-
 #endif

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -14,6 +14,9 @@
 #define poly_basemul(r, a, b) poly_basemul_montgomery(r, a, b, 0)
 #define poly_basemul_acc(r, a, b) poly_basemul_montgomery(r, a, b, 1)
 
+#define poly_frombytes_basemul(r, a, b) poly_frombytes_basemul_montgomery(r, a, b, 0)
+#define poly_frombytes_basemul_acc(r, a, b) poly_frombytes_basemul_montgomery(r, a, b, 1)
+
 /*
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
  * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]
@@ -31,9 +34,19 @@ void poly_decompress(poly *r, const uint8_t a[MLKEM_POLYCOMPRESSEDBYTES]);
 void poly_tobytes(uint8_t r[MLKEM_POLYBYTES], const poly *a);
 #define poly_frombytes MLKEM_NAMESPACE(poly_frombytes)
 void poly_frombytes(poly *r, const uint8_t a[MLKEM_POLYBYTES]);
+#define poly_frombytes_basemul_montgomery MLKEM_NAMESPACE(poly_frombytes_basemul_montgomery)
+void poly_frombytes_basemul_montgomery(poly *r, const poly *b, const unsigned char *a, int acc);
 
 #define poly_packcompress MLKEM_NAMESPACE(poly_packcompress)
 void poly_packcompress(unsigned char *r, poly *a, int i);
+
+#define cmp_poly_compress MLKEM_NAMESPACE(cmp_poly_compress)
+int cmp_poly_compress(const unsigned char *r, poly *a);
+#define cmp_poly_packcompress MLKEM_NAMESPACE(cmp_poly_packcompress)
+int cmp_poly_packcompress(const unsigned char *r, poly *a, int i);
+
+#define poly_unpackdecompress MLKEM_NAMESPACE(poly_unpackdecompress)
+void poly_unpackdecompress(poly *r, const unsigned char *a, int i);
 
 #define poly_frommsg MLKEM_NAMESPACE(poly_frommsg)
 void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES]);

--- a/mlkem/poly.h
+++ b/mlkem/poly.h
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "params.h"
 
+#define poly_getnoise_eta1(p, seed, nonce) poly_noise_eta1(p, seed, nonce, 0)
+#define poly_addnoise_eta1(p, seed, nonce) poly_noise_eta1(p, seed, nonce, 1)
+
 /*
  * Elements of R_q = Z_q[X]/(X^n + 1). Represents polynomial
  * coeffs[0] + X*coeffs[1] + X^2*coeffs[2] + ... + X^{n-1}*coeffs[n-1]
@@ -28,8 +31,8 @@ void poly_frommsg(poly *r, const uint8_t msg[MLKEM_INDCPA_MSGBYTES]);
 #define poly_tomsg MLKEM_NAMESPACE(poly_tomsg)
 void poly_tomsg(uint8_t msg[MLKEM_INDCPA_MSGBYTES], const poly *r);
 
-#define poly_getnoise_eta1 MLKEM_NAMESPACE(poly_getnoise_eta1)
-void poly_getnoise_eta1(poly *r, const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce);
+#define poly_noise_eta1 MLKEM_NAMESPACE(poly_noise_eta1)
+void poly_noise_eta1(poly *r, const unsigned char *seed, unsigned char nonce, int add);
 
 #define poly_getnoise_eta2 MLKEM_NAMESPACE(poly_getnoise_eta2)
 void poly_getnoise_eta2(poly *r, const uint8_t seed[MLKEM_SYMBYTES], uint8_t nonce);
@@ -50,5 +53,7 @@ void poly_reduce(poly *r);
 void poly_add(poly *r, const poly *a, const poly *b);
 #define poly_sub MLKEM_NAMESPACE(poly_sub)
 void poly_sub(poly *r, const poly *a, const poly *b);
+
+void poly_frommont(poly *r);
 
 #endif

--- a/mlkem/polyvec.c
+++ b/mlkem/polyvec.c
@@ -205,9 +205,9 @@ void polyvec_basemul_acc_montgomery(poly *r, const polyvec *a, const polyvec *b)
     unsigned int i;
     poly t;
 
-    poly_basemul_montgomery(r, &a->vec[0], &b->vec[0]);
+    poly_basemul(r, &a->vec[0], &b->vec[0]);
     for (i = 1; i < MLKEM_K; i++) {
-        poly_basemul_montgomery(&t, &a->vec[i], &b->vec[i]);
+        poly_basemul(&t, &a->vec[i], &b->vec[i]);
         poly_add(r, r, &t);
     }
 


### PR DESCRIPTION
This PR ports the stack-optimizations from https://github.com/mupq/pqm4 but without any assembly. 
It is heavily based on https://eprint.iacr.org/2019/489. 

Here are the current stack results: 

```
MLKEM-512:
==========================
keypair stack usage:
5296
encaps stack usage:
5352
decaps stack usage:
5352
OK KEYS

#
MLKEM-768:
==========================
keypair stack usage:
5760
encaps stack usage:
5816
decaps stack usage:
5816
OK KEYS

#
MLKEM-1024:
==========================
keypair stack usage:
6272
encaps stack usage:
6364
decaps stack usage:
6328
OK KEYS
```

You will see that this is not quite competitive with the state of the art yet. This is due to the stack usage in the Keccak permutation (2984 bytes). If you subtract that you get very close to the pqm4 numbers. 
I opened an issue to address that separatly #21 

Resolves #13 
