### PR TITLE
Use nix for building libopencm3 libraries instead of adding it as git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libopencm3"]
-	path = libopencm3
-	url = https://github.com/libopencm3/libopencm3.git

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ speed: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-speed)
 stack: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-stack)
 nistkat: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-nistkat)
 
-.PHONY: emulate clean libclean
+.PHONY: emulate clean
 
 emulate%: PLATFORM = mps2-an386
 emulate%: NTESTS = 10
@@ -39,5 +39,3 @@ clean:
 	$(Q)rm -rf elf/
 	$(Q)rm -rf bin/
 	$(Q)rm -rf obj/
-
-distclean: libclean clean

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ For example,
 - `make "emulate [test|speed|stack|nistkat]"` build binaries of test, speed, stack or nistkat for emulating `mps2-an386` on `QEMU` 
 - `make "emulate run" ELF_FILE=<ELF_FILE_NAME>` run emulatation for the file on `QEMU`
 - `make clean` cleans up intermediate artifacts
-- `make distclean` additionally cleanup the `libopencm3` library
 
 ### Manual testing on board
 After generating the specified hex files, you can flash it to the development board using `openocd`. 

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,9 @@
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, ... }:
         let
-          libopencm3 = pkgs.callPackage ./libopencm3.nix { };
+          libopencm3 = pkgs.callPackage ./libopencm3.nix {
+            targets = [ "stm32/f4" ];
+          };
           core = with pkgs; [
             # formatter & linters
             nixpkgs-fmt

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, ... }:
         let
+          libopencm3 = pkgs.callPackage ./libopencm3.nix { };
           core = with pkgs; [
             # formatter & linters
             nixpkgs-fmt
@@ -26,15 +27,18 @@
 
             # build dependencies
             gcc-arm-embedded-13 # arm-gnu-toolchain-13.2.rel1
-            qemu # 8.1.5
-            yq
-
             python311
+            qemu # 8.1.5
+            libopencm3
+
+
+            yq
             python311Packages.pyserial # 3.5
             python311Packages.click
           ];
         in
         {
+          packages.default = libopencm3;
           devShells.default = with pkgs; mkShellNoCC {
             packages = core ++ [
               direnv
@@ -45,6 +49,7 @@
             ];
 
             shellHook = ''
+              export OPENCM3_DIR=${libopencm3}
               export PATH=$PWD/scripts:$PWD/scripts/ci:$PATH
             '';
           };
@@ -53,6 +58,7 @@
             packages = core;
 
             shellHook = ''
+              export OPENCM3_DIR=${libopencm3}
               export PATH=$PWD/scripts:$PWD/scripts/ci:$PATH
             '';
           };

--- a/libopencm3.nix
+++ b/libopencm3.nix
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 { lib
-, stdenv
+, stdenvNoCC
 , fetchFromGitHub
 , python311
 , gcc-arm-embedded-13
 , targets ? [ ]
 }:
 
-stdenv.mkDerivation rec {
+stdenvNoCC.mkDerivation rec {
   pname = "libopencm3";
   version = "ec5aeba354ec273782e4441440fe9000b1c965e3";
   src = fetchFromGitHub {

--- a/libopencm3.nix
+++ b/libopencm3.nix
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+
+{ lib
+, stdenv
+, fetchFromGitHub
+, python311
+, gcc-arm-embedded-13
+}:
+
+stdenv.mkDerivation rec {
+  pname = "libopencm3";
+  version = "ec5aeba354ec273782e4441440fe9000b1c965e3";
+  src = fetchFromGitHub {
+    owner = "libopencm3";
+    repo = pname;
+    rev = "ec5aeba354ec273782e4441440fe9000b1c965e3";
+    sha256 = "sha256-bgoMhOhBJZwPTa9gUH0vPSGZknDrb2mJZuFlCWNivYU=";
+  };
+  buildInputs = [
+    python311
+    gcc-arm-embedded-13 # arm-gnu-toolchain-13.2.rel1
+  ];
+  buildPhase = ''
+    make lib
+  '';
+  installPhase = ''
+    mkdir -p $out
+    cp -r include/ $out/
+    cp -r ld/ $out/
+    cp -r lib/ $out/
+    cp -r mk/ $out/
+    cp --parent scripts/genlink.py $out/
+  '';
+  dontStrip = true;
+  dontPatchELF = true;
+  dontPatchShebangs = true;
+  noAuditTmpdir = true;
+
+  meta = with lib; {
+    description = "Open source ARM Cortex-M microcontroller library";
+    homepage = "https://libopencm3.org/";
+  };
+}

--- a/libopencm3.nix
+++ b/libopencm3.nix
@@ -5,6 +5,7 @@
 , fetchFromGitHub
 , python311
 , gcc-arm-embedded-13
+, targets ? [ ]
 }:
 
 stdenv.mkDerivation rec {
@@ -25,15 +26,19 @@ stdenv.mkDerivation rec {
   '';
   dontConfigure = true;
   buildPhase = ''
-    make lib
+    make ${if targets == [] then "lib" else "TARGETS=${lib.concatStrings targets}"}
   '';
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out
     cp -r include/ $out/
     cp -r ld/ $out/
     cp -r lib/ $out/
     cp -r mk/ $out/
     cp -r scripts/ $out/
+
+    runHook postInstall
   '';
   dontStrip = true;
   noAuditTmpdir = true;

--- a/libopencm3.nix
+++ b/libopencm3.nix
@@ -20,6 +20,10 @@ stdenv.mkDerivation rec {
     python311
     gcc-arm-embedded-13 # arm-gnu-toolchain-13.2.rel1
   ];
+  postPatch = ''
+    patchShebangs --build scripts/irq2nvic_h
+  '';
+  dontConfigure = true;
   buildPhase = ''
     make lib
   '';
@@ -29,11 +33,9 @@ stdenv.mkDerivation rec {
     cp -r ld/ $out/
     cp -r lib/ $out/
     cp -r mk/ $out/
-    cp --parent scripts/genlink.py $out/
+    cp -r scripts/ $out/
   '';
   dontStrip = true;
-  dontPatchELF = true;
-  dontPatchShebangs = true;
   noAuditTmpdir = true;
 
   meta = with lib; {

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -18,10 +18,6 @@ LIBDEPS += obj/libpqm4hal.a
 
 LDLIBS += -lc -lgcc
 
-OPENCM3_DIR = $(CURDIR)/libopencm3
-
-_git_submodule_update_opencm3 := $(shell git submodule update --init --recursive $(OPENCM3_DIR))
-
 ifeq ($(DEVICE),)
 $(warning no DEVICE specified for linker script generator)
 endif
@@ -58,15 +54,9 @@ endif
 LIBNAME = opencm3_$(genlink_family)
 
 LDLIBS += -l$(LIBNAME)
-LIBDEPS += $(OPENCM3_DIR)/lib/lib$(LIBNAME).a
 
 LDFLAGS += -L$(OPENCM3_DIR)/lib
 CPPFLAGS += -I$(OPENCM3_DIR)/include $(if $(KATRNG)==NIST,-Itest/common)
-
-$(OPENCM3_DIR)/lib/lib$(LIBNAME).a:
-	$(MAKE) -C $(OPENCM3_DIR) $(OPENCM3_TARGET)
-
-obj/hal/hal-opencm3.c.o: $(OPENCM3_DIR)/lib/lib$(LIBNAME).a
 
 LDSCRIPT = obj/generated.$(DEVICE).ld
 $(LDSCRIPT): $(OPENCM3_DIR)/ld/linker.ld.S $(OPENCM3_DIR)/ld/devices.data $(CONFIG)
@@ -101,10 +91,5 @@ LDFLAGS += \
 	-ffreestanding \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
-
-.PHONY: libclean
-
-libclean:
-	$(MAKE) -C $(OPENCM3_DIR) clean
 
 LINKDEPS += $(LDSCRIPT) $(LIBDEPS)

--- a/scripts/ci/lint
+++ b/scripts/ci/lint
@@ -41,7 +41,7 @@ echo "::endgroup::"
 
 check-eol-dry-run()
 {
-  for file in $(git ls-files -- ":/" ":/!:libopencm3"); do
+  for file in $(git ls-files -- ":/"); do
     if [[ $(tail -c1 "$file" | wc -l) == 0 ]]; then
       l=$(wc -l <"$file")
       echo "$file $l"
@@ -54,7 +54,7 @@ echo "::endgroup::"
 
 check-spdx()
 {
-  for file in $(git ls-files -- ":/" ":/!:libopencm3" ":/!:*LICENSE*" ":/!:.git*" ":/!:flake.lock"); do
+  for file in $(git ls-files -- ":/" ":/!:*LICENSE*" ":/!:.git*" ":/!:flake.lock"); do
     if [[ $(grep "SPDX-License-Identifier:" $file | wc -l) == 0 ]]; then
       echo "$file is missing SPDX License header"
       SUCCESS=false

--- a/scripts/format
+++ b/scripts/format
@@ -30,7 +30,7 @@ astyle $(git ls-files ":/*.c" ":/*.h") --options="$ROOT/.astylerc" --formatted |
 info "Checking for eol"
 check-eol()
 {
-  for file in $(git ls-files -- ":/" ":/!:libopencm3"); do
+  for file in $(git ls-files -- ":/"); do
     if [[ $(tail -c1 "$file" | wc -l) == 0 ]]; then
       echo "" >>"$file"
       echo "$file"


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
[//]: # (TODO Customize PR template)

[//]: # (See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository )

<!-- Please give a brief explanation of the purpose of this pull request. -->
- libopencm3 nix specification
- build using libopencm3 nix
- remove libopencm3 submodule

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
