### PR TITLE
Refactor makefile with libopencm3 module gcc and configuration dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       id: func_test
       shell: nix develop .#ci -c bash -e {0}
       run: |
-          tests func -e -v
+          tests func -e -v stm32f4discovery
     - name: Speed test
       id: speed_test
       shell: nix develop .#ci -c bash -e {0}
@@ -46,7 +46,7 @@ jobs:
         success()
         || steps.func_test.conclusion == 'failure'
       run: |
-          tests speed -e -v
+          tests speed -e -v stm32f4discovery
     - name: Stack test
       id: stack_test
       shell: nix develop .#ci -c bash -e {0}
@@ -55,7 +55,7 @@ jobs:
         || steps.func_test.conclusion == 'failure'
         || steps.speed_test.conclusion == 'failure'
       run: |
-          tests stack -e -v
+          tests stack -e -v stm32f4discovery
     - name: Nistkat test
       shell: nix develop .#ci -c bash -e {0}
       if: |
@@ -64,4 +64,4 @@ jobs:
         || steps.speed_test.conclusion == 'failure'
         || steps.stack_test.conclusion == 'failure'
       run: |
-        tests nistkat -e -v
+        tests nistkat -e -v stm32f4discovery

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
         script: |
           astyle --version
           arm-none-eabi-gcc --version
+          qemu-system-arm --version
     - name: Lint
       shell: nix develop .#ci -c bash -e {0}
       run: |
@@ -25,17 +26,7 @@ jobs:
       shell: nix develop .#ci -c bash -e {0}
       run: |
           make
-
-  emulate_test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Setup nix
-      uses: ./.github/actions/setup-nix
-      with:
-        script: |
-          arm-none-eabi-gcc --version
-          qemu-system-arm --version
+          make RNG=NISTKAT nistkat
     - name: Build for emulation on QEMU
       shell: nix develop .#ci -c bash -e {0}
       run: |
@@ -73,5 +64,4 @@ jobs:
         || steps.speed_test.conclusion == 'failure'
         || steps.stack_test.conclusion == 'failure'
       run: |
-        make clean
         tests nistkat -e -v

--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,13 @@ nistkat: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-nistkat)
 
 emulate%: PLATFORM = mps2-an386
 emulate%: NTESTS = 10
+emulate%: override RNG = NOTRAND
 
-emulate\ nistkat: KATRNG=NIST
-emulate\ nistkat:
-	$(Q)$(MAKE) PLATFORM=$(PLATFORM) NTESTS=$(NTESTS) KATRNG=$(KATRNG) nistkat
+emulate\ nistkat: override RNG = NISTKAT
 
 # emulate for test, speed, stack
 emulate%:
-	$(Q)$(MAKE) PLATFORM=$(PLATFORM) NTESTS=$(NTESTS) $*
+	$(Q)$(MAKE) PLATFORM=$(PLATFORM) NTESTS=$(NTESTS) RNG=$(RNG) $*
 
 emulate\ run: PLATFORM=mps2-an386
 emulate\ run:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For example,
 - `make [PLATFORM=<PLATFORM_NAME>] test` assembles all binaries for functional tests.
 - `make [PLATFORM=<PLATFORM_NAME>] speed` assembles all binaries for speed benchmarking
 - `make [PLATFORM=<PLATFORM_NAME>] stack` assembles all binaries for stack benchmarking
-- `make [PLATFORM=<PLATFORM_NAME>] KATRNG=NIST nistkat` assembles all binaries for nistkat
+- `make [PLATFORM=<PLATFORM_NAME>] RNG=NISTKAT nistkat` assembles all binaries for nistkat
 - `make [PLATFORM=<PLATFORM_NAME>] (all)` assembles all the above targets for all parameter sets.
 
 - `make emulate` build binaries for emulating `mps2-an386` on `QEMU` of test, speed, stack

--- a/flake.nix
+++ b/flake.nix
@@ -33,14 +33,12 @@
             qemu # 8.1.5
             libopencm3
 
-
             yq
             python311Packages.pyserial # 3.5
             python311Packages.click
           ];
         in
         {
-          packages.default = libopencm3;
           devShells.default = with pkgs; mkShellNoCC {
             packages = core ++ [
               direnv

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
             shellHook = ''
               export OPENCM3_DIR=${libopencm3}
               export PATH=$PWD/scripts:$PWD/scripts/ci:$PATH
+              eval "$(_TESTS_COMPLETE=source tests)"
             '';
           };
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -16,8 +16,27 @@ SIZE := $(CROSS_PREFIX)-size
 objs = $(addprefix obj/,$(addsuffix .o,$(1)))
 
 PLATFORM ?= stm32f4discovery
-KATRNG ?=
+RNG ?= HAL
 
+# RNG config
+ifeq ($(RNG),HAL)
+	LIBHAL_SRC += hal/randombytes.c
+else ifeq ($(RNG),NOTRAND)
+	LIBHAL_SRC += hal/notrandombytes.c
+else ifeq ($(RNG),NISTKAT)
+	LIBHAL_SRC += \
+		test/common/nistkatrng.c \
+		test/common/aes.c
+	CPPFLAGS += -Itest/common
+else
+	LIBHAL_SRC += hal/randombytes.c
+endif
+
+# HAL config
+LDLIBS += -lpqm4hal
+LIBDEPS += obj/libpqm4hal.a
+
+# Common config
 include mk/$(PLATFORM).mk
 
 CFLAGS += \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,6 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 SRCDIR := $(CURDIR)
 
+# GCC config
+CROSS_PREFIX ?= arm-none-eabi
+CC := $(CROSS_PREFIX)-gcc
+CPP := $(CROSS_PREFIX)-cpp
+AR := $(CROSS_PREFIX)-ar
+LD := $(CC)
+OBJCOPY := $(CROSS_PREFIX)-objcopy
+SIZE := $(CROSS_PREFIX)-size
+
 ###############
 # Some Macros #
 ###############
@@ -21,6 +30,18 @@ CFLAGS += \
 	$(CPPFLAGS)
 
 LDFLAGS += \
+	--specs=nosys.specs \
+	-Wl,--wrap=_sbrk \
+	-Wl,--wrap=_open \
+	-Wl,--wrap=_close \
+	-Wl,--wrap=_isatty \
+	-Wl,--wrap=_kill \
+	-Wl,--wrap=_lseek \
+	-Wl,--wrap=_read \
+	-Wl,--wrap=_write \
+	-Wl,--wrap=_fstat \
+	-Wl,--wrap=_getpid \
+	-ffreestanding \
 	-Lobj \
 	-Wl,--gc-sections
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+ifndef _CONFIG
+_CONFIG :=
+
 SRCDIR := $(CURDIR)
 
 # GCC config
@@ -10,6 +13,22 @@ LD := $(CC)
 OBJCOPY := $(CROSS_PREFIX)-objcopy
 SIZE := $(CROSS_PREFIX)-size
 
+##############################
+# Include retained variables #
+##############################
+
+RETAINED_VARS :=
+
+CONFIG := obj/.config.mk
+
+-include $(CONFIG)
+
+$(CONFIG):
+	@echo "  GEN     $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	@echo "# These variables are retained and can't be changed without a clean" > $@
+	@$(foreach var,$(RETAINED_VARS),echo "$(var) := $($(var))" >> $@; echo "LAST_$(var) := $($(var))" >> $@;)
+
 ###############
 # Some Macros #
 ###############
@@ -18,23 +37,24 @@ objs = $(addprefix obj/,$(addsuffix .o,$(1)))
 PLATFORM ?= stm32f4discovery
 RNG ?= HAL
 
+RETAINED_VARS += PLATFORM RNG
+
 # RNG config
 ifeq ($(RNG),HAL)
-	LIBHAL_SRC += hal/randombytes.c
+	LIBHAL_SRC = hal/randombytes.c
 else ifeq ($(RNG),NOTRAND)
-	LIBHAL_SRC += hal/notrandombytes.c
+	LIBHAL_SRC = hal/notrandombytes.c
 else ifeq ($(RNG),NISTKAT)
-	LIBHAL_SRC += \
+	LIBHAL_SRC = \
 		test/common/nistkatrng.c \
 		test/common/aes.c
 	CPPFLAGS += -Itest/common
-else
-	LIBHAL_SRC += hal/randombytes.c
 endif
 
+LDLIBS += -lhal
+LIBDEPS += obj/libhal.a
+
 # HAL config
-LDLIBS += -lpqm4hal
-LIBDEPS += obj/libpqm4hal.a
 
 # Common config
 include mk/$(PLATFORM).mk
@@ -65,7 +85,20 @@ LDFLAGS += \
 	-Wl,--gc-sections
 
 NTESTS ?= 1
+RETAINED_VARS += NTESTS
 
 KEM_SCHEMES=mlkem512 mlkem768 mlkem1024
 # mlkem k
 KEM_PARAMS=2 3 4
+
+define VAR_CHECK
+ifneq ($$(origin LAST_$(1)),undefined)
+ifneq "$$($(1))" "$$(LAST_$(1))"
+$$(info Variable $(1) changed, forcing rebuild!)
+.PHONY: $(CONFIG)
+endif
+endif
+endef
+
+$(foreach VAR,$(RETAINED_VARS),$(eval $(call VAR_CHECK,$(VAR))))
+endif

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -19,8 +19,8 @@ LIBHAL_SRC += \
 	hal/mps2/startup_MPS2.S \
 	hal/hal-mps2.c
 
-obj/libpqm4hal.a: $(call objs,$(LIBHAL_SRC))
-obj/libpqm4hal.a: CPPFLAGS += -Ihal/mps2 $(if $(RNG)==NISTKAT,-Itest/common)
+obj/libhal.a: $(call objs,$(LIBHAL_SRC))
+obj/libhal.a: CPPFLAGS += -Ihal/mps2 $(if $(RNG)==NISTKAT,-Itest/common)
 
 $(LDSCRIPT): CPPFLAGS += $(if $(MPS2_DATA_IN_FLASH),-DDATA_IN_FLASH)
 obj/hal/mps2/startup_MPS2.S.o: CPPFLAGS += $(if $(MPS2_DATA_IN_FLASH),-DDATA_IN_FLASH)

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -1,38 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 MPS2_DATA_IN_FLASH = 1
-CROSS_PREFIX ?= arm-none-eabi
-CC := $(CROSS_PREFIX)-gcc
-CPP := $(CROSS_PREFIX)-cpp
-AR := $(CROSS_PREFIX)-ar
-LD := $(CC)
-OBJCOPY := $(CROSS_PREFIX)-objcopy
-SIZE := $(CROSS_PREFIX)-size
 
-LDSCRIPT = obj/ldscript.ld
+LDSCRIPT = obj/generated.$(PLATFORM).ld
 
 ARCH_FLAGS += -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
 
-CFLAGS += \
-	$(ARCH_FLAGS) \
-	--specs=nosys.specs
+CFLAGS += $(ARCH_FLAGS)
 
 CPPFLAGS += \
 	-DMPS2_AN386
 
 LDFLAGS += \
-	--specs=nosys.specs \
-	-Wl,--wrap=_sbrk \
-	-Wl,--wrap=_open \
-	-Wl,--wrap=_close \
-	-Wl,--wrap=_isatty \
-	-Wl,--wrap=_kill \
-	-Wl,--wrap=_lseek \
-	-Wl,--wrap=_read \
-	-Wl,--wrap=_write \
-	-Wl,--wrap=_fstat \
-	-Wl,--wrap=_getpid \
 	-Wl,--no-warn-rwx-segments \
-	-ffreestanding \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -15,35 +15,21 @@ LDFLAGS += \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 
-LIBHAL_SRC := \
+LIBHAL_SRC += \
 	hal/mps2/startup_MPS2.S \
 	hal/hal-mps2.c
 
-ifndef KATRNG
-	LIBHAL_SRC += hal/notrandombytes.c
-else
-  ifeq ($(KATRNG),NIST)
-    LIBHAL_SRC += \
-	  test/common/nistkatrng.c \
-	  test/common/aes.c
-	CPPFLAGS += -Itest/common
-  endif
-endif
-
 obj/libpqm4hal.a: $(call objs,$(LIBHAL_SRC))
-obj/libpqm4hal.a: CPPFLAGS += -Ihal/mps2 $(if $(KATRNG)==NIST,-Itest/common)
+obj/libpqm4hal.a: CPPFLAGS += -Ihal/mps2 $(if $(RNG)==NISTKAT,-Itest/common)
 
 $(LDSCRIPT): CPPFLAGS += $(if $(MPS2_DATA_IN_FLASH),-DDATA_IN_FLASH)
 obj/hal/mps2/startup_MPS2.S.o: CPPFLAGS += $(if $(MPS2_DATA_IN_FLASH),-DDATA_IN_FLASH)
-
-LDLIBS += -lpqm4hal
-LIBDEPS += obj/libpqm4hal.a
 
 $(LDSCRIPT): hal/mps2/MPS2.ld
 	@printf "  GENLNK  $@\n"; \
 	[ -d $(@D) ] || $(Q)mkdir -p $(@D); \
 	$(CC) -x assembler-with-cpp -E -Wp,-P $(CPPFLAGS) $< -o $@
 
-$(LDSCRIPT): CPPFLAGS += -Ihal/mps2 $(if $(KATRNG)==NIST,-Itest/common)
+$(LDSCRIPT): CPPFLAGS += -Ihal/mps2 $(if $(RNG)==NISTKAT,-Itest/common)
 
 LINKDEPS += $(LDSCRIPT) $(LIBDEPS)

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,21 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-LIBHAL_SRC := hal/hal-opencm3.c
-
-ifndef KATRNG
-  LIBHAL_SRC += hal/randombytes.c
-else
-  ifeq ($(KATRNG),NIST)
-    LIBHAL_SRC += \
-	  test/common/nistkatrng.c \
-	  test/common/aes.c
-	CPPFLAGS += -Itest/common
-  endif
-endif
+LIBHAL_SRC += hal/hal-opencm3.c
 
 obj/libpqm4hal.a: $(call objs,$(LIBHAL_SRC))
-
-LDLIBS += -lpqm4hal
-LIBDEPS = obj/libpqm4hal.a
 
 CFLAGS += $(ARCH_FLAGS)
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -20,19 +20,7 @@ LIBDEPS = obj/libpqm4hal.a
 CFLAGS += $(ARCH_FLAGS)
 
 LDFLAGS += \
-	--specs=nosys.specs \
-	-Wl,--wrap=_sbrk \
-	-Wl,--wrap=_close \
-	-Wl,--wrap=_isatty \
-	-Wl,--wrap=_kill \
-	-Wl,--wrap=_lseek \
-	-Wl,--wrap=_read \
-	-Wl,--wrap=_write \
-	-Wl,--wrap=_fstat \
-	-Wl,--wrap=_getpid \
-	-Wl,--wrap=_open \
 	-nostartfiles \
-	-ffreestanding \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 LIBHAL_SRC += hal/hal-opencm3.c
 
-obj/libpqm4hal.a: $(call objs,$(LIBHAL_SRC))
+obj/libhal.a: $(call objs,$(LIBHAL_SRC))
 
 CFLAGS += $(ARCH_FLAGS)
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -8,72 +8,16 @@ else
     LIBHAL_SRC += \
 	  test/common/nistkatrng.c \
 	  test/common/aes.c
+	CPPFLAGS += -Itest/common
   endif
 endif
 
 obj/libpqm4hal.a: $(call objs,$(LIBHAL_SRC))
 
 LDLIBS += -lpqm4hal
-LIBDEPS += obj/libpqm4hal.a
+LIBDEPS = obj/libpqm4hal.a
 
-LDLIBS += -lc -lgcc
-
-ifeq ($(DEVICE),)
-$(warning no DEVICE specified for linker script generator)
-endif
-
-DEVICES_DATA ?= hal/devices.data
-
-genlink_family		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FAMILY)
-genlink_subfamily	:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) SUBFAMILY)
-genlink_cpu		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) CPU)
-genlink_fpu		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FPU)
-genlink_cppflags	:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) CPPFLAGS)
-
-ifeq ($(genlink_family),)
-$(warning $(DEVICE) not found in $(DEVICES_DATA))
-endif
-
-CPPFLAGS	+= $(genlink_cppflags)
-
-ARCH_FLAGS	:=-mcpu=$(genlink_cpu)
-ifeq ($(genlink_cpu),$(filter $(genlink_cpu),cortex-m0 cortex-m0plus cortex-m3 cortex-m4 cortex-m7))
-ARCH_FLAGS    +=-mthumb
-endif
-
-ifeq ($(genlink_fpu),soft)
-ARCH_FLAGS	+= -msoft-float
-else ifeq ($(genlink_fpu),hard-fpv4-sp-d16)
-ARCH_FLAGS	+= -mfloat-abi=hard -mfpu=fpv4-sp-d16
-else ifeq ($(genlink_fpu),hard-fpv5-sp-d16)
-ARCH_FLAGS      += -mfloat-abi=hard -mfpu=fpv5-sp-d16
-else
-$(warning No match for the FPU flags)
-endif
-
-LIBNAME = opencm3_$(genlink_family)
-
-LDLIBS += -l$(LIBNAME)
-
-LDFLAGS += -L$(OPENCM3_DIR)/lib
-CPPFLAGS += -I$(OPENCM3_DIR)/include $(if $(KATRNG)==NIST,-Itest/common)
-
-LDSCRIPT = obj/generated.$(DEVICE).ld
-$(LDSCRIPT): $(OPENCM3_DIR)/ld/linker.ld.S $(OPENCM3_DIR)/ld/devices.data $(CONFIG)
-	@printf "  GENLNK  $(DEVICE)\n"
-	$(Q)mkdir -p $(@D)
-	$(Q)$(CPP) $(ARCH_FLAGS) $(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) DEFS) -P -E $< -o $@
-
-CROSS_PREFIX ?= arm-none-eabi
-CC := $(CROSS_PREFIX)-gcc
-CPP := $(CROSS_PREFIX)-cpp
-AR := $(CROSS_PREFIX)-gcc-ar
-LD := $(CC)
-OBJCOPY := $(CROSS_PREFIX)-objcopy
-SIZE := $(CROSS_PREFIX)-size
-
-CFLAGS += \
-	$(ARCH_FLAGS) \
+CFLAGS += $(ARCH_FLAGS)
 
 LDFLAGS += \
 	--specs=nosys.specs \

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,4 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
+OPENCM3_DIR ?=
+override LDSCRIPT := obj/generated.$(DEVICE).ld
+
+include $(OPENCM3_DIR)/mk/genlink-config.mk
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include $(OPENCM3_DIR)/mk/gcc-rules.mk
+
 LIBHAL_SRC += hal/hal-opencm3.c
 
 obj/libhal.a: $(call objs,$(LIBHAL_SRC))

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -1,25 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
-elf/%.elf:
+elf/%.elf: $(CONFIG)
 	@echo "  LD      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(LD) $(LDFLAGS) -o $@ $(filter %.o,$^) -Wl,--start-group $(LDLIBS) -Wl,--end-group
 
-obj/%.a:
+obj/%.a: $(CONFIG)
 	@echo "  AR      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(Q)$(AR) rcs $@ $(filter %.o,$^)
+	$(eval REMOVES := $(filter-out $(filter %.o,$^),$(shell $(AR) t $@)))
+	@echo "  AR d    $(REMOVES)"
+	$(Q)$(if $(REMOVES),rm $@,)
+	$(Q)$(AR) rcsT $@ $(filter %.o,$^)
 
-bin/%.bin: elf/%.elf
+bin/%.bin: elf/%.elf $(CONFIG)
 	@echo "  OBJCOPY $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(OBJCOPY) -Obinary $< $@
 
-bin/%.hex: elf/%.elf
+bin/%.hex: elf/%.elf $(CONFIG)
 	@echo "  OBJCOPY $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(OBJCOPY) -Oihex $< $@
 
-obj/%.o: %.c
+obj/%.o: %.c $(CONFIG)
 	@echo "  CC      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -7,10 +7,8 @@ elf/%.elf: $(CONFIG)
 obj/%.a: $(CONFIG)
 	@echo "  AR      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
-	$(eval REMOVES := $(filter-out $(filter %.o,$^),$(shell $(AR) t $@)))
-	@echo "  AR d    $(REMOVES)"
-	$(Q)$(if $(REMOVES),rm $@,)
-	$(Q)$(AR) rcsT $@ $(filter %.o,$^)
+	$(Q)rm -f $@
+	$(Q)$(AR) rcs $@ $(filter %.o,$^)
 
 bin/%.bin: elf/%.elf $(CONFIG)
 	@echo "  OBJCOPY $@"

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -6,23 +6,23 @@ OBJS = $(call objs,$(addprefix $(1)/,$(notdir $(basename $(MLKEM_SOURCES)))) $(b
 
 define scheme-test
 $(1)-test: CPPFLAGS += -DMLKEM_K=$(2) -DNTESTS=$$(NTESTS)
-$(1)-test: bin/$(1)-test.hex
+$(1)-test: bin/$(1)-test.hex $(CONFIG)
 
 $(1)-speed: CPPFLAGS += -DMLKEM_K=$(2) -DNTESTS=$$(NTESTS)
-$(1)-speed: bin/$(1)-speed.hex
+$(1)-speed: bin/$(1)-speed.hex $(CONFIG)
 
 $(1)-stack: CPPFLAGS += -DMLKEM_K=$(2)
-$(1)-stack: bin/$(1)-stack.hex
+$(1)-stack: bin/$(1)-stack.hex $(CONFIG)
 
 $(1)-nistkat: CPPFLAGS += -DMLKEM_K=$(2)
-$(1)-nistkat: bin/$(1)-nistkat.hex
+$(1)-nistkat: bin/$(1)-nistkat.hex $(CONFIG)
 endef
 
 define scheme-elf
-elf/$(1)-test.elf: obj/test/$(1)-test.o $(call OBJS,$(1)) $(LINKDEPS)
-elf/$(1)-speed.elf: obj/test/$(1)-speed.o $(call OBJS,$(1)) $(LINKDEPS)
-elf/$(1)-stack.elf: obj/test/$(1)-stack.o $(call OBJS,$(1)) $(LINKDEPS)
-elf/$(1)-nistkat.elf: obj/test/$(1)-nistkat.o $(call OBJS,$(1)) $(LINKDEPS)
+elf/$(1)-test.elf: obj/test/$(1)-test.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
+elf/$(1)-speed.elf: obj/test/$(1)-speed.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
+elf/$(1)-stack.elf: obj/test/$(1)-stack.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
+elf/$(1)-nistkat.elf: obj/test/$(1)-nistkat.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
 endef
 
 define compile-obj
@@ -32,21 +32,21 @@ define compile-obj
 endef
 
 define scheme-obj
-obj/$(1)/%.o: mlkem/%.c
+obj/$(1)/%.o: mlkem/%.c $(CONFIG)
 	$$(compile-obj)
 endef
 
 define scheme-test-obj
-obj/test/$(1)-test.o: test/test.c
+obj/test/$(1)-test.o: test/test.c $(CONFIG)
 	$$(compile-obj)
 
-obj/test/$(1)-speed.o: test/speed.c
+obj/test/$(1)-speed.o: test/speed.c $(CONFIG)
 	$$(compile-obj)
 
-obj/test/$(1)-stack.o: test/stack.c
+obj/test/$(1)-stack.o: test/stack.c $(CONFIG)
 	$$(compile-obj)
 
-obj/test/$(1)-nistkat.o: test/nistkat.c
+obj/test/$(1)-nistkat.o: test/nistkat.c $(CONFIG)
 	$$(compile-obj)
 endef
 

--- a/mk/stm32f4discovery.mk
+++ b/mk/stm32f4discovery.mk
@@ -6,7 +6,6 @@ override LDSCRIPT := obj/generated.$(DEVICE).ld
 override DEVICES_DATA := hal/devices.data
 
 include $(OPENCM3_DIR)/mk/genlink-config.mk
-include $(OPENCM3_DIR)/mk/gcc-config.mk
 include $(OPENCM3_DIR)/mk/genlink-rules.mk
 include $(OPENCM3_DIR)/mk/gcc-rules.mk
 include mk/opencm3.mk

--- a/mk/stm32f4discovery.mk
+++ b/mk/stm32f4discovery.mk
@@ -1,5 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 DEVICE=stm32f407vg
 OPENCM3_TARGET=lib/stm32/f4
+OPENCM3_DIR ?=
+override LDSCRIPT := obj/generated.$(DEVICE).ld
+override DEVICES_DATA := hal/devices.data
 
+include $(OPENCM3_DIR)/mk/genlink-config.mk
+include $(OPENCM3_DIR)/mk/gcc-config.mk
+include $(OPENCM3_DIR)/mk/genlink-rules.mk
+include $(OPENCM3_DIR)/mk/gcc-rules.mk
 include mk/opencm3.mk

--- a/mk/stm32f4discovery.mk
+++ b/mk/stm32f4discovery.mk
@@ -1,11 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 DEVICE=stm32f407vg
 OPENCM3_TARGET=lib/stm32/f4
-OPENCM3_DIR ?=
-override LDSCRIPT := obj/generated.$(DEVICE).ld
 override DEVICES_DATA := hal/devices.data
 
-include $(OPENCM3_DIR)/mk/genlink-config.mk
-include $(OPENCM3_DIR)/mk/genlink-rules.mk
-include $(OPENCM3_DIR)/mk/gcc-rules.mk
 include mk/opencm3.mk

--- a/scripts/tests
+++ b/scripts/tests
@@ -79,7 +79,13 @@ def count(bstr, match):
 
 
 def base_test(
-    test_type, emulate, platform_cfg, ntests, expect_proc, actual_proc, verbose
+    test_type,
+    emulate,
+    platform,
+    ntests,
+    expect_proc,
+    actual_proc,
+    verbose,
 ):
     """
     test_type: test, speed, stack, nistkat
@@ -89,17 +95,19 @@ def base_test(
     config_logger(verbose)
 
     if emulate:
-        subprocess.run(
-            ["make", f"NTESTS={ntests}", f"emulate {test_type}"],
-            stdout=subprocess.DEVNULL,
-        )
+        platform = getattr(platform_map, platform).qemu_platform
     else:
-        subprocess.run(
-            ["make", f"{test_type}"]
-            + [f"NTESTS={ntests}"] * (test_type != "nistkat")
-            + ["RNG=NISTKAT"] * (test_type == "nistkat"),
-            stdout=subprocess.DEVNULL,
-        )
+        platform_cfg = getattr(platform_map, platform).openocd_cfg
+
+    p = subprocess.run(
+        ["make", f"NTESTS={ntests}", f"PLATFORM={platform}"]
+        + [f"emulate {test_type}"] * emulate
+        + ["RNG=NISTKAT"] * (test_type == "nistkat")
+        + ["RNG=NOTRND"] * (emulate and test_type != "nistkat")
+        + ["RNG=HAL"] * (not emulate and test_type != "nistkat"),
+        stdout=subprocess.DEVNULL if not verbose else None,
+    )
+    logging.info(format(subprocess.list2cmdline(p.args)))
 
     def check(file, expect, actual):
         if actual != expect:
@@ -119,7 +127,8 @@ def base_test(
         if emulate:
             actual = actual_proc(
                 subprocess.run(
-                    ["make", "emulate run", f"ELF_FILE={file}"], capture_output=True
+                    ["make", "emulate run", f"ELF_FILE={file}", f"PLATFORM={platform}"],
+                    capture_output=True,
                 ).stdout
             )
         else:
@@ -131,13 +140,6 @@ def base_test(
 # cli utilities
 
 _shared_options = [
-    click.option(
-        "-cfg",
-        "--platform-cfg",
-        default="hal/stm32f4discovery.cfg",
-        type=click.Path(),
-        help="Configuration file of the specified platform",
-    ),
     click.option(
         "-v",
         "--verbose",
@@ -158,18 +160,60 @@ _shared_options = [
     ),
 ]
 
+_shared_args = [
+    click.argument(
+        "platform",
+        nargs=1,
+        type=click.Choice(["stm32f4discovery"]),
+    )
+]
+
 
 def add_options(options):
     return lambda func: reduce(lambda f, o: o(f), reversed(options), func)
 
 
+def add_args(args):
+    return lambda func: reduce(lambda f, o: o(f), reversed(args), func)
+
+
 # commands
+from types import SimpleNamespace
+
+
+class RecursiveNamespace(SimpleNamespace):
+
+    @staticmethod
+    def map_entry(entry):
+        if isinstance(entry, dict):
+            return RecursiveNamespace(**entry)
+
+        return entry
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        for key, val in kwargs.items():
+            if type(val) == dict:
+                setattr(self, key, RecursiveNamespace(**val))
+            elif type(val) == list:
+                setattr(self, key, list(map(self.map_entry, val)))
+
+
+platform_map = RecursiveNamespace(
+    **{
+        "stm32f4discovery": {
+            "qemu_platform": "mps2-an386",
+            "openocd_cfg": "board/stm32f4discovery.cfg",
+        }
+    }
+)
 
 
 @click.command(
     short_help="Run for the specified platform and hex file without parsing the output",
     context_settings={"show_default": True},
 )
+@add_args(_shared_args)
 @add_options(_shared_options)
 @click.option(
     "-b",
@@ -177,12 +221,14 @@ def add_options(options):
     type=click.Path(),
     help="The binary hex file that you wanted to test.",
 )
-def run(platform_cfg, bin, verbose, emulate):
+def run(platform, bin, verbose, emulate):
     config_logger(True)
     dev = usbdev()
 
     try:
-        result = asyncio.run(flush_and_read(dev, platform_cfg, bin))
+        result = asyncio.run(
+            flush_and_read(dev, getattr(platform_map, platform).openocd_cfg, bin)
+        )
         logging.info(result)
     except asyncio.CancelledError:
         pass
@@ -191,14 +237,15 @@ def run(platform_cfg, bin, verbose, emulate):
 @click.command(
     short_help="Run functional tests", context_settings={"show_default": True}
 )
+@add_args(_shared_args)
 @add_options(_shared_options)
 @click.option("-i", "--iterations", default=1, type=int, help="Number of tests")
-def func(platform_cfg, iterations, verbose, emulate):
+def func(platform, iterations, verbose, emulate):
     try:
         base_test(
             "test",
             emulate,
-            platform_cfg,
+            platform,
             iterations,
             lambda _: iterations * 3,
             lambda output: count(output, "OK"),
@@ -210,13 +257,14 @@ def func(platform_cfg, iterations, verbose, emulate):
 
 @click.command(short_help="Run speed tests", context_settings={"show_default": True})
 @add_options(_shared_options)
+@add_options(_shared_args)
 @click.option("-i", "--iterations", default=1, type=int, help="Number of tests")
-def speed(platform_cfg, iterations, verbose, emulate):
+def speed(platform, iterations, verbose, emulate):
     try:
         base_test(
             "speed",
             emulate,
-            platform_cfg,
+            platform,
             iterations,
             lambda _: iterations,
             lambda output: count(output, "OK"),
@@ -228,12 +276,13 @@ def speed(platform_cfg, iterations, verbose, emulate):
 
 @click.command(short_help="Run stack tests", context_settings={"show_default": True})
 @add_options(_shared_options)
-def stack(platform_cfg, verbose, emulate):
+@add_options(_shared_args)
+def stack(platform, verbose, emulate):
     try:
         base_test(
             "stack",
             emulate,
-            platform_cfg,
+            platform,
             0,
             lambda _: 1,
             lambda output: count(output, "OK"),
@@ -245,7 +294,8 @@ def stack(platform_cfg, verbose, emulate):
 
 @click.command(short_help="Run nistkat tests", context_settings={"show_default": True})
 @add_options(_shared_options)
-def nistkat(platform_cfg, verbose, emulate):
+@add_options(_shared_args)
+def nistkat(platform, verbose, emulate):
     def scheme_hash(scheme):
         result = subprocess.run(
             [
@@ -267,7 +317,7 @@ def nistkat(platform_cfg, verbose, emulate):
         base_test(
             "nistkat",
             emulate,
-            platform_cfg,
+            platform,
             0,
             scheme_hash,
             lambda output: str(output, encoding="utf-8").strip().lower(),

--- a/scripts/tests
+++ b/scripts/tests
@@ -102,6 +102,7 @@ def base_test(
     p = subprocess.run(
         ["make", f"NTESTS={ntests}", f"PLATFORM={platform}"]
         + [f"emulate {test_type}"] * emulate
+        + [f"{test_type}"] * (not emulate)
         + ["RNG=NISTKAT"] * (test_type == "nistkat")
         + ["RNG=NOTRND"] * (emulate and test_type != "nistkat")
         + ["RNG=HAL"] * (not emulate and test_type != "nistkat"),

--- a/scripts/tests
+++ b/scripts/tests
@@ -97,7 +97,7 @@ def base_test(
         subprocess.run(
             ["make", f"{test_type}"]
             + [f"NTESTS={ntests}"] * (test_type != "nistkat")
-            + ["KATRNG=NIST"] * (test_type == "nistkat"),
+            + ["RNG=NISTKAT"] * (test_type == "nistkat"),
             stdout=subprocess.DEVNULL,
         )
 


### PR DESCRIPTION
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
[//]: # (TODO Customize PR template)

[//]: # (See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository )

<!-- Please give a brief explanation of the purpose of this pull request. -->
Refactor makefile such that make clean is not needed anymore.
But sometimes you might need to specify the retained variables (i.e. `PLATFORM`, `RNG`,... which are stored in `obj/.config.mk`) for consecutive makes.

In order to make consecutive run of the `tests` script success without running any `make clean`, it is sometimes necessary to specify the target platform so that the retained variables can be overwritten. Therefore the interface of the `tests` script is changed as follow (take command `func` for example):
```
> tests func --help                                                                                                                                                            
Usage: tests func [OPTIONS] {stm32f4discovery}

Options:
  -v, --verbose             Show verbose output or not
  -e, --emulate             Emulate on the QEMU or not
  -i, --iterations INTEGER  Number of tests  [default: 1]
  --help                    Show this message and exit.
```

Typing the full platform name is somehow tedious, I also added a shell hook to the nix shell, so that one can autocomplete with tabs.

- libopencm3 nix cleanup
- refactor with libopencm3 module gcc
- refactor common gcc config for different platform
- refactor RNG makefile config
- add makefile config dependency
- merge ci tests since there is no need for make clean between different configuration
- move opencm3 configs inside mk/opencm3.mk
- remove obj/libhal.a whenever dependencies changed
- add platform as an optional argument to the test script
- add shell completion for the tests script

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
