### PR TITLE
Refactor makefile by reducing some unreadable macros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-.PHONY: all
+.PHONY: all test speed stack nistkat
 
 all: test speed stack nistkat
 
@@ -10,7 +10,15 @@ include mk/rules.mk
 
 Q ?= @
 
-$(TESTS): % : $(call SCHEMES,%)
+nistkat:
+	$(Q)$(MAKE) RNG=NISTKAT PLATFORM=$(PLATFORM) mlkem512-$@
+	$(Q)$(MAKE) RNG=NISTKAT PLATFORM=$(PLATFORM) mlkem768-$@
+	$(Q)$(MAKE) RNG=NISTKAT PLATFORM=$(PLATFORM) mlkem1024-$@
+
+test speed stack:
+	$(Q)$(MAKE) PLATFORM=$(PLATFORM) mlkem512-$@
+	$(Q)$(MAKE) PLATFORM=$(PLATFORM) mlkem768-$@
+	$(Q)$(MAKE) PLATFORM=$(PLATFORM) mlkem1024-$@
 
 .PHONY: emulate clean
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,7 @@
 
 .PHONY: all
 
-all: test speed stack
-
+all: test speed stack nistkat
 
 include mk/config.mk
 include mk/schemes.mk
@@ -11,10 +10,7 @@ include mk/rules.mk
 
 Q ?= @
 
-test: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-test)
-speed: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-speed)
-stack: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-stack)
-nistkat: $(foreach scheme,$(KEM_SCHEMES),$(scheme)-nistkat)
+$(TESTS): % : $(call SCHEMES,%)
 
 .PHONY: emulate clean
 

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -88,6 +88,8 @@ LDFLAGS += \
 NTESTS ?= 1
 RETAINED_VARS += NTESTS
 
+TESTS = test speed stack nistkat
+
 KEM_SCHEMES=mlkem512 mlkem768 mlkem1024
 # mlkem k
 KEM_PARAMS=2 3 4

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -39,8 +39,8 @@ RNG ?= HAL
 
 RETAINED_VARS += PLATFORM RNG
 
-LDLIBS += -lhal
-LIBDEPS += obj/libhal.a
+LDLIBS += -lhal -Lobj/hal
+LIBDEPS += obj/hal/libhal.a
 
 # Common config
 include mk/$(PLATFORM).mk
@@ -68,7 +68,6 @@ LDFLAGS += \
 	-Wl,--wrap=_fstat \
 	-Wl,--wrap=_getpid \
 	-ffreestanding \
-	-Lobj \
 	-Wl,--gc-sections
 
 NTESTS ?= 1

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -39,22 +39,8 @@ RNG ?= HAL
 
 RETAINED_VARS += PLATFORM RNG
 
-# RNG config
-ifeq ($(RNG),HAL)
-	LIBHAL_SRC = hal/randombytes.c
-else ifeq ($(RNG),NOTRAND)
-	LIBHAL_SRC = hal/notrandombytes.c
-else ifeq ($(RNG),NISTKAT)
-	LIBHAL_SRC = \
-		test/common/nistkatrng.c \
-		test/common/aes.c
-	CPPFLAGS += -Itest/common
-endif
-
 LDLIBS += -lhal
 LIBDEPS += obj/libhal.a
-
-# HAL config
 
 # Common config
 include mk/$(PLATFORM).mk

--- a/mk/mbed-os.mk
+++ b/mk/mbed-os.mk
@@ -1,4 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
+ifeq ($(RNG),NISTKAT)
+	LIBHAL_SRC = \
+		test/common/nistkatrng.c \
+		test/common/aes.c
+	CPPFLAGS += -Itest/common
+else
+	RNG := NOTRAND
+	LIBHAL_SRC = hal/notrandombytes.c
+endif
+
 LDSCRIPT = obj/generated.$(PLATFORM).ld
 
 CFLAGS += $(ARCH_FLAGS)
@@ -23,4 +33,3 @@ $(LDSCRIPT): 	$(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
 $(LDSCRIPT): CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
 
 LINKDEPS += $(LDSCRIPT) $(LIBDEPS)
-

--- a/mk/mbed-os.mk
+++ b/mk/mbed-os.mk
@@ -18,12 +18,19 @@ LDFLAGS += \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 
-LIBHAL_SRC += hal/hal-mps2.c $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+LIBHAL_SRC += hal/hal-mps2.c
+STARTUP_SRC = $(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+STARTUP_OBJ = $(shell echo "$(STARTUP_SRC)" | sed -E 's/(.*\/)(TARGET.*)/obj\/hal\/\2.o/g')
 
 MPS2_DEPS += -I$(MBED_OS_DIR)/Include -I$(MBED_OS_TARGET_DIR)
 
-obj/libhal.a: $(call objs,$(LIBHAL_SRC))
-obj/libhal.a: CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
+obj/hal/libhal.a: $(call objs,$(LIBHAL_SRC)) $(STARTUP_OBJ)
+obj/hal/libhal.a: CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
+
+$(STARTUP_OBJ): $(STARTUP_SRC)
+	@echo "  AS      $@"
+	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
+	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 
 $(LDSCRIPT): 	$(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
 	@printf "  GENLNK  $@\n"; \

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,4 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
+ifeq ($(RNG),NISTKAT)
+	LIBHAL_SRC = \
+		test/common/nistkatrng.c \
+		test/common/aes.c
+	CPPFLAGS += -Itest/common
+else
+	RNG := HAL
+	LIBHAL_SRC = hal/randombytes.c
+endif
+
 OPENCM3_DIR ?=
 override LDSCRIPT := obj/generated.$(DEVICE).ld
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -18,7 +18,7 @@ include $(OPENCM3_DIR)/mk/gcc-rules.mk
 
 LIBHAL_SRC += hal/hal-opencm3.c
 
-obj/libhal.a: $(call objs,$(LIBHAL_SRC))
+obj/hal/libhal.a: $(call objs,$(LIBHAL_SRC))
 
 CFLAGS += $(ARCH_FLAGS)
 

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -4,10 +4,8 @@ FIPS202_SOURCES = $(wildcard fips202/*.c)
 
 OBJS = $(call objs,$(addprefix $(1)/,$(notdir $(basename $(MLKEM_SOURCES)))) $(basename $(FIPS202_SOURCES)))
 
-SCHEMES = $(KEM_SCHEMES:%=%-$(1))
-
 # all tests x all schemes
-SCHEMES_TESTS = $(foreach t,$(TESTS),$(call SCHEMES,$(t)))
+SCHEMES_TESTS = $(foreach t,$(TESTS),$(KEM_SCHEMES:%=%-$(t)))
 
 # set up tests dependencies for each scheme
 define SCHEME_DEPS

--- a/mk/schemes.mk
+++ b/mk/schemes.mk
@@ -4,63 +4,48 @@ FIPS202_SOURCES = $(wildcard fips202/*.c)
 
 OBJS = $(call objs,$(addprefix $(1)/,$(notdir $(basename $(MLKEM_SOURCES)))) $(basename $(FIPS202_SOURCES)))
 
-define scheme-test
-$(1)-test: CPPFLAGS += -DMLKEM_K=$(2) -DNTESTS=$$(NTESTS)
-$(1)-test: bin/$(1)-test.hex $(CONFIG)
+SCHEMES = $(KEM_SCHEMES:%=%-$(1))
 
-$(1)-speed: CPPFLAGS += -DMLKEM_K=$(2) -DNTESTS=$$(NTESTS)
-$(1)-speed: bin/$(1)-speed.hex $(CONFIG)
+# all tests x all schemes
+SCHEMES_TESTS = $(foreach t,$(TESTS),$(call SCHEMES,$(t)))
 
-$(1)-stack: CPPFLAGS += -DMLKEM_K=$(2)
-$(1)-stack: bin/$(1)-stack.hex $(CONFIG)
-
-$(1)-nistkat: CPPFLAGS += -DMLKEM_K=$(2)
-$(1)-nistkat: bin/$(1)-nistkat.hex $(CONFIG)
+# set up tests dependencies for each scheme
+define SCHEME_DEPS
+$(TESTS:%=$(1)-%): CPPFLAGS += -DMLKEM_K=$(2) -DNTESTS=$(NTESTS)
 endef
 
-define scheme-elf
-elf/$(1)-test.elf: obj/test/$(1)-test.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
-elf/$(1)-speed.elf: obj/test/$(1)-speed.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
-elf/$(1)-stack.elf: obj/test/$(1)-stack.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
-elf/$(1)-nistkat.elf: obj/test/$(1)-nistkat.o $(call OBJS,$(1)) $(LINKDEPS) $(CONFIG)
+define SCHEME_ELF_DEPS
+$(TESTS:%=elf/$(1)-%.elf): elf/%.elf: obj/test/%.o $(call OBJS,$(1)) $(LINKDEPS)
 endef
 
-define compile-obj
+define COMPILE_OBJ
 	@echo "  CC      $@"
 	$(Q)[ -d $(@D) ] || mkdir -p $(@D)
 	$(Q)$(CC) -c -o $@ $(CFLAGS) $<
 endef
 
-define scheme-obj
+# compile object file for each scheme
+define SCHEME_OBJ
 obj/$(1)/%.o: mlkem/%.c $(CONFIG)
-	$$(compile-obj)
+	$$(COMPILE_OBJ)
 endef
 
-define scheme-test-obj
-obj/test/$(1)-test.o: test/test.c $(CONFIG)
-	$$(compile-obj)
-
-obj/test/$(1)-speed.o: test/speed.c $(CONFIG)
-	$$(compile-obj)
-
-obj/test/$(1)-stack.o: test/stack.c $(CONFIG)
-	$$(compile-obj)
-
-obj/test/$(1)-nistkat.o: test/nistkat.c $(CONFIG)
-	$$(compile-obj)
+define SCHEME_TEST_OBJS
+obj/test/$(1)-%.o: test/%.c $(CONFIG)
+	$$(COMPILE_OBJ)
 endef
 
-# iterate over schemes and params to generate targets for functional test and speed benchmark
-iter=$(let scheme k rest,$(1), \
-	$(eval $(call scheme-test,$(scheme),$(k))) \
-	$(if $(rest),$(call iter,$(rest)) ))
-$(call iter,$(subst -, ,$(join $(addsuffix -,$(KEM_SCHEMES)),$(KEM_PARAMS))))
+$(SCHEMES_TESTS): % : bin/%.bin bin/%.hex
+
+$(eval $(call SCHEME_DEPS,mlkem512,2))
+$(eval $(call SCHEME_DEPS,mlkem768,3))
+$(eval $(call SCHEME_DEPS,mlkem1024,4))
 
 $(foreach scheme,$(KEM_SCHEMES), \
-	$(eval $(call scheme-elf,$(scheme))))
+	$(eval $(call SCHEME_ELF_DEPS,$(scheme))))
 
 $(foreach scheme,$(KEM_SCHEMES), \
-	$(eval $(call scheme-obj,$(scheme))))
+	$(eval $(call SCHEME_TEST_OBJS,$(scheme))))
 
 $(foreach scheme,$(KEM_SCHEMES), \
-	$(eval $(call scheme-test-obj,$(scheme))))
+	$(eval $(call SCHEME_OBJ,$(scheme))))

--- a/scripts/ci/tests-qemu
+++ b/scripts/ci/tests-qemu
@@ -13,6 +13,7 @@ _run()
   echo "::group:: $test_type test for $platform"
   tests "$test_type" "$platform" -v
   code=$?
+  sleep 1
   echo "::endgroup::"
   return $code
 }


### PR DESCRIPTION
- **refactor macro used in schemes.mk**
- **add nistkat to all targets**
- **tmp workaround for linked to obsolete files**
- **move hal related artifacts to obj/hal**

[//]: # (SPDX-License-Identifier: CC-BY-4.0)
[//]: # (TODO Customize PR template)

[//]: # (See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository )

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
