### PR TITLE
Add support to ESP32C3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,7 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.3; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.3/direnvrc" "sha256-0EVQVNSRQWsln+rgPW3mXVmnF5sfcmKEYOmOSfLYxHg="
 fi
 
+watch_file mbed-os.nix
+watch_file libopencm3.nix
+watch_file esp-idf-lib.nix
 use flake

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,6 +44,7 @@ jobs:
 
           export -f make_platform
           tests --list-platforms | grep -v "mps2" | xargs -I {} bash -c 'make_platform "$@" || exit 1' _ {}
+          make_platform "esp32-c3"
 
     - name: Functional test
       id: func_test

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
         script: |
           astyle --version
           arm-none-eabi-gcc --version
+          riscv32-esp-elf-gcc --version
           qemu-system-arm --version
     - name: Lint
       run: |

--- a/esp-idf-lib.nix
+++ b/esp-idf-lib.nix
@@ -8,8 +8,9 @@
 , fetchPypi
 }:
 let
-  version = "v5.2.2";
+  version = "v5.3";
 
+  # new dependency for v5.2.x
   pyclang = python3Packages.buildPythonPackage rec {
     pname = "pyclang";
     version = "0.4.2";
@@ -22,13 +23,37 @@ let
     doCheck = false;
   };
 
+  # new dependency for v5.3
+  esp-idf-nvs-partition-gen = python3Packages.buildPythonPackage rec {
+    pname = "esp_idf_nvs_partition_gen";
+    version = "0.1.2";
+    format = "pyproject";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-HjW5RCKfy83LQgAs0tOW/f9LPVoLwHY1pyb6ar+AxwY=";
+    };
+
+    propagatedBuildInputs = builtins.attrValues {
+      inherit (python3Packages)
+        setuptools
+        cryptography;
+    };
+
+    doCheck = false;
+  };
+
   esp-idf-esp32c3' = (esp-idf-esp32c3.overrideAttrs (old: {
-    propagatedBuildInputs = builtins.filter (p: p != git) old.propagatedBuildInputs ++ [ pyclang ];
+    propagatedBuildInputs = builtins.filter (p: p != git) old.propagatedBuildInputs ++
+      [
+        pyclang
+        esp-idf-nvs-partition-gen
+      ];
     patches = [ ];
   })
   ).override {
     rev = version;
-    sha256 = "sha256-I4YxxSGdQT8twkoFx3zmZhyLTSagmeLD2pygVfY/pEk=";
+    sha256 = "sha256-w+xyva4t21STVtfYZOXY2xw6sDc2XvJXBZSx+wd1N6Y=";
   };
 in
 stdenvNoCC.mkDerivation {

--- a/esp-idf-lib.nix
+++ b/esp-idf-lib.nix
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+
+{ stdenvNoCC
+, writeText
+, esp-idf-esp32c3
+, git
+, python3Packages
+, fetchPypi
+}:
+let
+  version = "v5.2.2";
+
+  pyclang = python3Packages.buildPythonPackage rec {
+    pname = "pyclang";
+    version = "0.4.2";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-vuDZ5yEhyDpCmkXoC+Gr2X5vMK5B46HnktcvBONjxXM=";
+    };
+
+    doCheck = false;
+  };
+
+  esp-idf-esp32c3' = (esp-idf-esp32c3.overrideAttrs (old: {
+    propagatedBuildInputs = builtins.filter (p: p != git) old.propagatedBuildInputs ++ [ pyclang ];
+    patches = [ ];
+  })
+  ).override {
+    rev = version;
+    sha256 = "sha256-I4YxxSGdQT8twkoFx3zmZhyLTSagmeLD2pygVfY/pEk=";
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "esp-idf-esp32c3-lib";
+  version = version;
+
+  dontUnpack = true; # start with empt src
+  dontConfigure = true;
+
+  # set environment variables for downstreams
+  setupHook = writeText "setup-hook.sh" ''
+    export ESP_IDF_DIR="${esp-idf-esp32c3'}"
+    export ESP_IDF_LIB="$1"
+  '';
+
+  buildInputs = [ esp-idf-esp32c3' git ];
+  propagatedBuildInputs = [ esp-idf-esp32c3' ];
+
+  buildPhase = ''
+    cp --no-preserve=mode,ownership -r "$IDF_PATH/examples/get-started/hello_world" ./
+    idf.py -C hello_world set-target esp32c3
+    idf.py -C hello_world build
+  '';
+  installPhase = ''
+    mkdir -p $out/esp32c3
+    mv ./hello_world/build/esp-idf/* $out/esp32c3/
+  '';
+}

--- a/esp-idf-lib.nix
+++ b/esp-idf-lib.nix
@@ -78,7 +78,9 @@ stdenvNoCC.mkDerivation {
     idf.py -C hello_world build
   '';
   installPhase = ''
-    mkdir -p $out/esp32c3
-    mv ./hello_world/build/esp-idf/* $out/esp32c3/
+    mkdir -p $out/esp32c3/bootloader
+    mv ./hello_world/build/esp-idf $out/esp32c3/
+    mv ./hello_world/build/bootloader/esp-idf $out/esp32c3/bootloader
+    mv ./hello_world/build/bootloader/config $out/esp32c3/bootloader
   '';
 }

--- a/fips202/keccakf1600.c
+++ b/fips202/keccakf1600.c
@@ -31,8 +31,8 @@ Please refer to LowLevel.build for the exact list of other files it must be comb
 #define IS_BIG_ENDIAN      4321
 #define IS_LITTLE_ENDIAN   1234
 
-#if defined(__arm__)
-# ifdef __BIG_ENDIAN
+#if defined(__arm__) || defined(__riscv)
+# if defined(__BIG_ENDIAN) || defined(__ORDER_BIG_ENDIAN__)
 #  define PLATFORM_BYTE_ORDER IS_BIG_ENDIAN
 # else
 #  define PLATFORM_BYTE_ORDER IS_LITTLE_ENDIAN
@@ -152,7 +152,7 @@ void KeccakP1600_AddLanes(KeccakP1600_plain32_state *state, const unsigned char 
                         | ((uint32_t)(laneAsBytes[5]) << 8)
                         | ((uint32_t)(laneAsBytes[6]) << 16)
                         | ((uint32_t)(laneAsBytes[7]) << 24);
-        uint32_t even, odd, temp, temp0, temp1;
+        uint32_t temp, temp0, temp1;
         uint32_t *stateAsHalfLanes = state->A;
         toBitInterleavingAndXOR(low, high, stateAsHalfLanes[lanePosition * 2 + 0], stateAsHalfLanes[lanePosition * 2 + 1], temp, temp0, temp1);
     }
@@ -203,7 +203,7 @@ static void KeccakP1600_ExtractLanes(const KeccakP1600_plain32_state *state, uns
     #else
     unsigned int lanePosition;
     for (lanePosition = 0; lanePosition < laneCount; lanePosition++) {
-        uint32_t *stateAsHalfLanes = state->A;
+        const uint32_t *stateAsHalfLanes = state->A;
         uint32_t low, high, temp, temp0, temp1;
         fromBitInterleaving(stateAsHalfLanes[lanePosition * 2], stateAsHalfLanes[lanePosition * 2 + 1], low, high, temp, temp0, temp1);
         uint8_t laneAsBytes[8];

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,27 @@
 {
   "nodes": {
+    "esp-dev": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1718773764,
+        "narHash": "sha256-e1PD1kCXX00+0AyaFb5mGkkkNfKx+xdLvVVnoMBvQuo=",
+        "owner": "mirrexagon",
+        "repo": "nixpkgs-esp-dev",
+        "rev": "86a2bbe01fe0258887de7396af2a5eb0e37ac3be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mirrexagon",
+        "repo": "nixpkgs-esp-dev",
+        "rev": "86a2bbe01fe0258887de7396af2a5eb0e37ac3be",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -17,6 +39,24 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -38,8 +78,24 @@
     },
     "root": {
       "inputs": {
+        "esp-dev": "esp-dev",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -64,8 +64,7 @@
           };
 
           riscv-pkgs = builtins.attrValues {
-            inherit (pkgs)
-              esp-idf-esp32c3;
+            esp-idf-lib = pkgs.callPackage ./esp-idf-lib.nix { };
           };
 
           wrapShell = mkShell: attrs:

--- a/flake.nix
+++ b/flake.nix
@@ -23,13 +23,6 @@
       systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { pkgs, system, ... }:
         let
-          libopencm3 = pkgs.callPackage ./libopencm3.nix {
-            targets = [ "stm32/f2" "stm32/f4" "stm32/f7" ];
-          };
-          mbed-os = pkgs.callPackage ./mbed-os.nix {
-            targets = [ "TARGET_MPS2_M3" "TARGET_MPS2_M4" "TARGET_MPS2_M7" ];
-          };
-
           core = builtins.attrValues {
             astyle = pkgs.astyle.overrideAttrs (old: rec {
               version = "3.4.13";
@@ -57,8 +50,14 @@
           };
 
           arm-pkgs = builtins.attrValues {
-            libopencm3 = libopencm3;
-            mbed-os = mbed-os;
+            libopencm3 = pkgs.callPackage ./libopencm3.nix {
+              targets = [ "stm32/f2" "stm32/f4" "stm32/f7" ];
+            };
+
+            mbed-os = pkgs.callPackage ./mbed-os.nix {
+              targets = [ "TARGET_MPS2_M3" "TARGET_MPS2_M4" "TARGET_MPS2_M7" ];
+            };
+
             inherit (pkgs)
               gcc-arm-embedded-13; # arm-gnu-toolchain-13.2.rel1
           };
@@ -91,14 +90,10 @@
                 # debug dependencies
                 openocd; # 0.12.0
             };
-            OPENCM3_DIR = ''${libopencm3}'';
-            MBED_OS_DIR = ''${mbed-os}'';
           };
 
           devShells.ci = wrapShell pkgs.mkShellNoCC {
             packages = core ++ arm-pkgs;
-            OPENCM3_DIR = ''${libopencm3}'';
-            MBED_OS_DIR = ''${mbed-os}'';
           };
 
           devShells.ci-riscv = wrapShell pkgs.mkShellNoCC {

--- a/flake.nix
+++ b/flake.nix
@@ -40,8 +40,6 @@
             });
 
             inherit (pkgs)
-              esp-idf-esp32c3
-
               # formatter & linters
               nixpkgs-fmt
               shfmt
@@ -65,6 +63,11 @@
               gcc-arm-embedded-13; # arm-gnu-toolchain-13.2.rel1
           };
 
+          riscv-pkgs = builtins.attrValues {
+            inherit (pkgs)
+              esp-idf-esp32c3;
+          };
+
           wrapShell = mkShell: attrs:
             mkShell (attrs // {
               shellHook = ''
@@ -81,7 +84,7 @@
           };
 
           devShells.default = wrapShell pkgs.mkShellNoCC {
-            packages = core ++ arm-pkgs ++ builtins.attrValues {
+            packages = core ++ arm-pkgs ++ riscv-pkgs ++ builtins.attrValues {
               inherit (pkgs)
                 direnv
                 nix-direnv
@@ -97,6 +100,10 @@
             packages = core ++ arm-pkgs;
             OPENCM3_DIR = ''${libopencm3}'';
             MBED_OS_DIR = ''${mbed-os}'';
+          };
+
+          devShells.ci-riscv = wrapShell pkgs.mkShellNoCC {
+            packages = core ++ riscv-pkgs;
           };
         };
       flake = {

--- a/flake.nix
+++ b/flake.nix
@@ -93,11 +93,7 @@
           };
 
           devShells.ci = wrapShell pkgs.mkShellNoCC {
-            packages = core ++ arm-pkgs;
-          };
-
-          devShells.ci-riscv = wrapShell pkgs.mkShellNoCC {
-            packages = core ++ riscv-pkgs;
+            packages = core ++ arm-pkgs ++ riscv-pkgs;
           };
         };
       flake = {

--- a/hal/esp32-c3.ld
+++ b/hal/esp32-c3.ld
@@ -1,0 +1,61 @@
+MEMORY {
+    iflash   (x): org = 0x42000000, len = 0x400000
+    dflash   (r): org = 0x3C000000, len = 0x400000
+    sram    (rw): org = 0x3FC80000, len = 0x50000
+    rtc_ram (rx): org = 0x50000000, len = 0x2000
+}
+
+ENTRY(_start)
+
+SECTIONS {
+  .header : AT(0)
+  {
+    _iflash_start = .;
+    LONG(0xaedb041d)
+    LONG(0xaedb041d)
+  } > iflash
+
+  .text.entry : {
+    KEEP(*(.text.entry))
+  } > iflash
+
+  .text : {
+    *(.text .stub .text.* .gnu.linkonce.t.*)
+  } > iflash
+  _iflash_end = .;
+  _iflash_size = _iflash_end - _iflash_start;
+
+  _dflash_start = ORIGIN(dflash) + _iflash_size;
+  .rodata _dflash_start : AT(_iflash_size) {
+    *(.rodata .rodata* .srodata .srodata* .sdata2 .sdata2* .gnu.linkonce.r.*)
+  } > dflash
+  _dflash_end = .;
+  _dflash_size = _dflash_end - _dflash_start;
+
+  .data ORIGIN(sram) : AT(_iflash_size + _dflash_size) {
+    _data_start = .;
+    *(.data .data* .gnu.linkonce.r.* .riscv.*)
+  } > sram
+
+  .sdata : {
+    _sdata_start = .;
+    *(.sdata .sdata.* .gnu.linkonce.s.*)
+  }
+  _data_end = .;
+  _data_lma_start = ORIGIN(dflash) + LOADADDR(.data);
+
+  .bss : {
+    _bss_start = .;
+    *(.bss .bss* .sbss .sbss* COMMON)
+    _bss_end = .;
+  } > sram
+
+  __global_pointer$ = _sdata_start + 0x800;
+
+  .stack : {
+    _stack_bottom = .;
+    _stack_top = ORIGIN(sram) + LENGTH(sram);
+    _stack_size_min = 0x4000;
+    ASSERT(_stack_bottom + _stack_size_min < _stack_top, "Error: no space for stack");
+  }
+}

--- a/hal/esp32-c3.ld
+++ b/hal/esp32-c3.ld
@@ -1,4 +1,4 @@
-/*SPDX-License-Identifier: Apache-2.0*/
+/*SPDX-License-Identifier: MIT*/
 MEMORY {
     iflash   (x): org = 0x42000000, len = 0x400000
     dflash   (r): org = 0x3C000000, len = 0x400000

--- a/hal/esp32-c3.ld
+++ b/hal/esp32-c3.ld
@@ -1,3 +1,4 @@
+/*SPDX-License-Identifier: Apache-2.0*/
 MEMORY {
     iflash   (x): org = 0x42000000, len = 0x400000
     dflash   (r): org = 0x3C000000, len = 0x400000

--- a/hal/esp32-c3.ld
+++ b/hal/esp32-c3.ld
@@ -1,7 +1,7 @@
 /*SPDX-License-Identifier: MIT*/
 MEMORY {
-    iflash   (x): org = 0x42000000, len = 0x400000
-    dflash   (r): org = 0x3C000000, len = 0x400000
+    irom   (x): org = 0x42000000, len = 0x400000
+    drom   (r): org = 0x3C000000, len = 0x400000
     sram    (rw): org = 0x3FC80000, len = 0x50000
     rtc_ram (rx): org = 0x50000000, len = 0x2000
 }
@@ -9,27 +9,33 @@ MEMORY {
 ENTRY(_start)
 
 SECTIONS {
-  .header : AT(0)
+  .header (READONLY): AT(0)
   {
     _iflash_start = .;
     LONG(0xaedb041d)
     LONG(0xaedb041d)
-  } > iflash
+  } > irom
 
   .text.entry : {
     KEEP(*(.text.entry))
-  } > iflash
+  } > irom
 
   .text : {
     *(.text .stub .text.* .gnu.linkonce.t.*)
-  } > iflash
+  } > irom
+
+  .iram : {
+    *(.iram .iram*)
+  } > irom
+
   _iflash_end = .;
   _iflash_size = _iflash_end - _iflash_start;
 
-  _dflash_start = ORIGIN(dflash) + _iflash_size;
+  _dflash_start = ORIGIN(drom) + _iflash_size;
   .rodata _dflash_start : AT(_iflash_size) {
     *(.rodata .rodata* .srodata .srodata* .sdata2 .sdata2* .gnu.linkonce.r.*)
-  } > dflash
+  } > drom
+
   _dflash_end = .;
   _dflash_size = _dflash_end - _dflash_start;
 
@@ -41,9 +47,9 @@ SECTIONS {
   .sdata : {
     _sdata_start = .;
     *(.sdata .sdata.* .gnu.linkonce.s.*)
-  }
+  } > sram
   _data_end = .;
-  _data_lma_start = ORIGIN(dflash) + LOADADDR(.data);
+  _data_lma_start = ORIGIN(drom) + LOADADDR(.data);
 
   .bss : {
     _bss_start = .;

--- a/hal/esp32c3_start.S
+++ b/hal/esp32c3_start.S
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
     .section .text.entry
     .type _entry, @function
     .global _entry

--- a/hal/esp32c3_start.S
+++ b/hal/esp32c3_start.S
@@ -1,0 +1,53 @@
+    .section .text.entry
+    .type _entry, @function
+    .global _entry
+_entry:
+    .option push
+    .option norelax
+    la a0, _data_start
+    la a1, _data_lma_start
+    la a2, _data_end
+    sub a2, a2, a0
+    call memcpy
+    .option pop
+    j _start
+
+    .section .text
+    .type   _start, @function
+    .global _start
+_start:
+    .option push
+    .option norelax
+    la gp, __global_pointer$
+    .option pop
+
+    la      a0, _bss_start
+    la      a2, _bss_end
+    sub     a2, a2, a0
+    li      a1, 0
+    call    memset
+
+    la sp,  _stack_top
+
+    /* Call main */
+    la      a0, _main_argc
+    lw      a0, 0(a0)
+    la      a1, _main_argv
+    li      a2, 0
+    call    main
+    tail    exit
+
+    .size  _start, .-_start
+
+    .section .data
+    .global _main_argc
+    .weak _main_argc
+_main_argc:
+    .word 1
+_argv_0:
+    .string ""
+    .global _main_argv
+    .weak _main_argv
+_main_argv:
+    .word _argv_0
+

--- a/hal/esp32c3_start.S
+++ b/hal/esp32c3_start.S
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
     .section .text.entry
     .type _entry, @function
     .global _entry

--- a/hal/hal-esp-idf.c
+++ b/hal/hal-esp-idf.c
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <hal.h>
+#include <hal/systimer_hal.h>
+#include <hal/wdt_hal.h>
+#include <hal/cache_ll.h>
+#include <hal/cache_hal.h>
+#include <soc/soc.h>
+#include <esp_private/systimer.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdio.h>
+
+extern int main();
+
+/*NOTE: refer to esp-idf/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld*/
+extern int _bss_start;
+extern int _bss_end;
+extern int bootloader_usable_dram_end; /* start of the stack */
+static char *stack_start = &bootloader_usable_dram_end;
+static systimer_hal_context_t hal_ctx;
+
+extern int uart_tx_one_char(uint8_t c);
+void hal_setup(const enum clock_mode clock) {
+    systimer_hal_init(&hal_ctx);
+    systimer_hal_tick_rate_ops_t ops = {
+        .ticks_to_us = systimer_ticks_to_us,
+        .us_to_ticks = systimer_us_to_ticks,
+    };
+
+    systimer_hal_set_tick_rate_ops(&hal_ctx, &ops);
+    systimer_hal_enable_counter(&hal_ctx, 0);
+};
+
+void hal_send_str(const char *in) {
+    const char *cur = in;
+    while (*cur) {
+        uart_tx_one_char(*cur);
+        cur += 1;
+    }
+    uart_tx_one_char('\n');
+}
+
+
+/* Reference: what have done in `esp_timer_impl_get_time` in esp_timer/src/esp_timer_impl_systimer.c` */
+uint64_t hal_get_time(void) {
+    return systimer_hal_get_time(&hal_ctx, 0);
+}
+
+size_t hal_get_stack_size(void) {
+    register char *cur_stack;
+    __asm__ volatile ("mv %0, sp" : "=r"(cur_stack));
+    return cur_stack - stack_start;
+
+}
+
+void hal_spraystack(void) {}
+size_t hal_checkstack(void) { return 0; }
+
+void __attribute__((noreturn)) call_start_cpu0(void) {
+    memset(&_bss_start, 0, (&_bss_end - &_bss_start) * sizeof(_bss_start));
+
+    wdt_hal_context_t wdt0_context = {.inst = WDT_MWDT0, .mwdt_dev = &TIMERG0};
+    wdt_hal_write_protect_disable(&wdt0_context);
+    wdt_hal_disable(&wdt0_context);
+    wdt_hal_set_flashboot_en(&wdt0_context, false);
+
+    wdt_hal_context_t rwdt_context = RWDT_HAL_CONTEXT_DEFAULT();
+    wdt_hal_write_protect_disable(&rwdt_context);
+    wdt_hal_disable(&rwdt_context);
+    wdt_hal_set_flashboot_en(&rwdt_context, false);
+
+    REG_WRITE(RTC_CNTL_SWD_WPROTECT_REG, RTC_CNTL_SWD_WKEY_VALUE);
+    REG_SET_BIT(RTC_CNTL_SWD_CONF_REG, RTC_CNTL_SWD_AUTO_FEED_EN);
+    REG_WRITE(RTC_CNTL_SWD_WPROTECT_REG, 0);
+
+    cache_hal_init();
+    cache_hal_is_cache_enabled(CACHE_LL_ID_ALL, CACHE_TYPE_ALL);
+
+    hal_setup(CLOCK_BENCHMARK);
+
+    char buf[1024];
+    snprintf(buf, 1024, "stack start: %X\n", (int)&bootloader_usable_dram_end);
+    hal_send_str(buf);
+
+    (void) main();
+
+    for (;;) (void) 0;
+}
+
+
+#include <errno.h>
+#undef errno
+extern int errno;
+
+int __wrap__open(char *file, int flags, int mode) {
+    (void) file;
+    (void) flags;
+    (void) mode;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__close(int fd) {
+    errno = ENOSYS;
+    (void) fd;
+    return -1;
+}
+
+#include <sys/stat.h>
+
+int __wrap__fstat(int fd, struct stat *buf) {
+    (void) fd;
+    (void) buf;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__getpid(void) {
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__isatty(int file) {
+    (void) file;
+    errno = ENOSYS;
+    return 0;
+}
+
+int __wrap__kill(int pid, int sig) {
+    (void) pid;
+    (void) sig;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__lseek(int fd, int ptr, int dir) {
+    (void) fd;
+    (void) ptr;
+    (void) dir;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__read(int fd, char *ptr, int len) {
+    (void) fd;
+    (void) ptr;
+    (void) len;
+    errno = ENOSYS;
+    return -1;
+}
+
+int __wrap__write(int fd, const char *ptr, int len) {
+    (void) fd;
+    (void) ptr;
+    (void) len;
+    errno = ENOSYS;
+    return -1;
+}
+
+void *__wrap__sbrk (int incr) {
+    char *prev_heap_end;
+    prev_heap_end = stack_start;
+    stack_start += incr;
+
+    return (void *) prev_heap_end;
+}
+
+struct _reent * __getreent(void)
+{
+    return _impure_ptr;
+}
+

--- a/hal/hal-esp-idf.c
+++ b/hal/hal-esp-idf.c
@@ -5,10 +5,13 @@
 #include <hal/cache_ll.h>
 #include <hal/cache_hal.h>
 #include <hal/clk_tree_ll.h>
+#include <hal/clk_tree_hal.h>
+#include <hal/uart_ll.h>
 #include <esp_cpu.h>
 #include <bootloader_random.h>
 #include <soc/soc.h>
 #include <soc/clk_tree_defs.h>
+#include <soc/uart_struct.h>
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -20,6 +23,7 @@ extern char _stack_bottom; /* start of the stack */
 static char *stack_start = &_stack_bottom;
 static systimer_hal_context_t hal_ctx;
 
+#define SERIAL_BAUD 38400
 extern int uart_tx_one_char(uint8_t c);
 
 void hal_setup(const enum clock_mode clock) {
@@ -41,6 +45,10 @@ void hal_setup(const enum clock_mode clock) {
 
     cache_hal_init();
     cache_hal_is_cache_enabled(CACHE_LL_ID_ALL, CACHE_TYPE_ALL);
+
+    uart_ll_sclk_enable(UART_LL_GET_HW(UART_NUM_0));
+    uart_ll_set_sclk(UART_LL_GET_HW(UART_NUM_0), SOC_MOD_CLK_APB);
+    uart_ll_set_baudrate(UART_LL_GET_HW(UART_NUM_0), SERIAL_BAUD, CLK_LL_AHB_MAX_FREQ_MHZ * MHZ);
 
     // setup for cycle count
     systimer_hal_init(&hal_ctx);

--- a/hal/hal-esp-idf.c
+++ b/hal/hal-esp-idf.c
@@ -6,6 +6,7 @@
 #include <hal/cache_hal.h>
 #include <hal/clk_tree_ll.h>
 #include <esp_cpu.h>
+#include <bootloader_random.h>
 #include <soc/soc.h>
 #include <soc/clk_tree_defs.h>
 #include <string.h>
@@ -57,6 +58,8 @@ void hal_setup(const enum clock_mode clock) {
         clk_ll_cpu_set_freq_mhz_from_pll(CLK_LL_PLL_160M_FREQ_MHZ);
         break;
     }
+
+    bootloader_random_enable();
 };
 
 void hal_send_str(const char *in) {

--- a/hal/hal-esp-idf.c
+++ b/hal/hal-esp-idf.c
@@ -59,7 +59,6 @@ void hal_setup(const enum clock_mode clock) {
     clk_ll_cpu_set_src(SOC_CPU_CLK_SRC_PLL);
     switch (clock) {
     case CLOCK_BENCHMARK:
-        // TODO: need to check with the datasheet
         // max clock frequency for flash
         clk_ll_cpu_set_freq_mhz_from_pll(CLK_LL_PLL_80M_FREQ_MHZ);
         break;

--- a/hal/hal-esp-idf.c
+++ b/hal/hal-esp-idf.c
@@ -25,7 +25,7 @@ extern char _stack_bottom; /* end of the stack */
 static char *stack_bottom = &_stack_bottom;
 static systimer_hal_context_t hal_ctx;
 
-#define SERIAL_BAUD 38400
+#define SERIAL_BAUD 115200
 extern int uart_tx_one_char(uint8_t c);
 
 void hal_setup(const enum clock_mode clock) {

--- a/hal/randombytes.c
+++ b/hal/randombytes.c
@@ -4,6 +4,9 @@
 #ifdef RISCV
 #include <esp_random.h>
 int randombytes(uint8_t *obuf, size_t len) {
+    // NOTE:
+    // After enableing the internal entropy source (SAR ADC), random numbers are then generated based on the thermal noise in the system and the asynchronous clock mismatch.
+    // For more detail please refer to https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32c3/api-reference/system/random.html and the technical reference manual
     esp_fill_random(obuf, len);
 
     return 0;

--- a/hal/randombytes.c
+++ b/hal/randombytes.c
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "randombytes.h"
 
+#ifdef RISCV
+#include <bootloader_random.h>
+int randombytes(uint8_t *obuf, size_t len) {
+    bootloader_fill_random(obuf, len);
+
+    return 0;
+}
+
+#else
 #include <libopencm3/stm32/rng.h>
 
 int randombytes(uint8_t *obuf, size_t len) {
@@ -25,3 +34,4 @@ int randombytes(uint8_t *obuf, size_t len) {
 
     return 0;
 }
+#endif

--- a/hal/randombytes.c
+++ b/hal/randombytes.c
@@ -2,9 +2,9 @@
 #include "randombytes.h"
 
 #ifdef RISCV
-#include <bootloader_random.h>
+#include <esp_random.h>
 int randombytes(uint8_t *obuf, size_t len) {
-    bootloader_fill_random(obuf, len);
+    esp_fill_random(obuf, len);
 
     return 0;
 }

--- a/hal/randombytes.c
+++ b/hal/randombytes.c
@@ -5,7 +5,7 @@
 #include <esp_random.h>
 int randombytes(uint8_t *obuf, size_t len) {
     // NOTE:
-    // After enableing the internal entropy source (SAR ADC), random numbers are then generated based on the thermal noise in the system and the asynchronous clock mismatch.
+    // After enabling the internal entropy source (SAR ADC), random numbers are generated based on the thermal noise in the system and the asynchronous clock mismatch.
     // For more detail please refer to https://docs.espressif.com/projects/esp-idf/en/v5.3/esp32c3/api-reference/system/random.html and the technical reference manual
     esp_fill_random(obuf, len);
 

--- a/libopencm3.nix
+++ b/libopencm3.nix
@@ -3,6 +3,7 @@
 { lib
 , stdenvNoCC
 , fetchFromGitHub
+, writeText
 , python311
 , gcc-arm-embedded-13
 , targets ? [ ]
@@ -17,6 +18,9 @@ stdenvNoCC.mkDerivation rec {
     rev = "ec5aeba354ec273782e4441440fe9000b1c965e3";
     sha256 = "sha256-bgoMhOhBJZwPTa9gUH0vPSGZknDrb2mJZuFlCWNivYU=";
   };
+  setupHook = writeText "setup-hook.sh" ''
+    export OPENCM3_DIR="$1"
+  '';
   buildInputs = [
     python311
     gcc-arm-embedded-13 # arm-gnu-toolchain-13.2.rel1

--- a/mbed-os.nix
+++ b/mbed-os.nix
@@ -2,12 +2,16 @@
 
 { stdenvNoCC
 , fetchFromGitHub
+, writeText
 , targets ? [ ]
 }:
 
 stdenvNoCC.mkDerivation rec {
   pname = "mbed-os";
   version = "e04a55f32b0ac0ead9c1eb0b488a20e4e2617130";
+  setupHook = writeText "setup-hook.sh" ''
+    export MBED_OS_DIR="$1"
+  '';
   src = fetchFromGitHub {
     owner = "ARMmbed";
     repo = pname;

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -41,7 +41,7 @@ include mk/$(PLATFORM).mk
 
 CFLAGS += \
 	-O3 \
-	-std=gnu17 \
+	-std=gnu99 \
 	--sysroot=$(SYSROOT) \
 	-Wall -Wextra -Wshadow -Werror \
 	-MMD \

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -4,15 +4,6 @@ _CONFIG :=
 
 SRCDIR := $(CURDIR)
 
-# GCC config
-CROSS_PREFIX ?= arm-none-eabi
-CC := $(CROSS_PREFIX)-gcc
-CPP := $(CROSS_PREFIX)-cpp
-AR := $(CROSS_PREFIX)-ar
-LD := $(CC)
-OBJCOPY := $(CROSS_PREFIX)-objcopy
-SIZE := $(CROSS_PREFIX)-size
-
 ##############################
 # Include retained variables #
 ##############################
@@ -39,8 +30,9 @@ $(CONFIG):
 # Some Macros #
 ###############
 
-LDLIBS += -lhal -L$(OBJ_DIR)/hal
-LIBDEPS += $(OBJ_DIR)/hal/libhal.a
+LDLIBS += -lpqcphal -L$(OBJ_DIR)/hal
+LIBDEPS += $(OBJ_DIR)/hal/libpqcphal.a
+LINKDEPS += $(LIBDEPS)
 
 # Common config
 objs = $(addprefix $(OBJ_DIR)/,$(addsuffix .o,$(1)))
@@ -49,7 +41,7 @@ include mk/$(PLATFORM).mk
 
 CFLAGS += \
 	-O3 \
-	-std=gnu99 \
+	-std=gnu17 \
 	--sysroot=$(SYSROOT) \
 	-Wall -Wextra -Wshadow -Werror \
 	-MMD \

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -24,13 +24,8 @@ endif
 
 LIBHAL_SRC += hal/hal-esp-idf.c hal/esp32c3_start.S
 
-$(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC))
-
-ARCH_FLAGS += -march=rv32imc_zicsr_zifencei 
-
-CPPFLAGS += -DRISCV -DESP32C3
-
-CFLAGS += \
+$(OBJ_DIR)/hal/libpqcphal.a: CFLAGS += \
+	-std=gnu17 \
 	-I$(IDF_PATH)/components/soc/include \
 	-I$(IDF_PATH)/components/soc/esp32c3/include \
 	-I$(IDF_PATH)/components/esp_rom/include \
@@ -42,7 +37,15 @@ CFLAGS += \
 	-I$(IDF_PATH)/components/esp_hw_support/include \
 	-I$(IDF_PATH)/components/bootloader_support/include \
 	-I$(IDF_PATH)/components/riscv/include \
-	-I$(ESP_IDF_LIB)/esp32c3/bootloader/config \
+	-I$(ESP_IDF_LIB)/esp32c3/bootloader/config
+
+$(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC))
+
+ARCH_FLAGS += -march=rv32imc_zicsr_zifencei
+
+CPPFLAGS += -DRISCV -DESP32C3
+
+CFLAGS += \
 	$(ARCH_FLAGS) \
 	-fdata-sections -ffunction-sections \
 	-nostartfiles -Og

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+
+IDF_PATH ?=
+ESP_IDF_LIB ?=
+LDSCRIPTS = \
+	$(IDF_PATH)/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld \
+	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.api.ld \
+	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.ld \
+	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld \
+	$(IDF_PATH)/components/soc/esp32c3/ld/esp32c3.peripherals.ld
+
+LIBHAL_SRC += hal/hal-esp-idf.c
+
+obj/libhal.a: $(call objs,$(LIBHAL_SRC))
+
+ARCH_FLAGS += -march=rv32imc_zicsr_zifencei 
+
+CPPFLAGS += -DRISCV -DESP32C3
+
+CFLAGS += $(ARCH_FLAGS)
+
+# platform specific ldflags
+LDFLAGS += \
+	-lesp_rom -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/esp_rom \
+	-lsoc -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/soc \
+	-lesp_common -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/esp_common \
+	-lesp_hw_support -L$(ESP_IDF_LIB)/esp32c3/esp-idf/esp_hw_support \
+	-lhal -L$(ESP_IDF_LIB)/esp32c3/esp-idf/hal \
+	-lg_nano
+
+LDFLAGS += \
+	-nostdlib \
+	-nostartfiles \
+	$(addprefex -T,$(LDSCRIPTS)) \
+	$(ARCH_FLAGS)

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -22,7 +22,7 @@ else
 	LIBHAL_SRC = hal/notrandombytes.c
 endif
 
-LIBHAL_SRC += hal/hal-esp-idf.c
+LIBHAL_SRC += hal/hal-esp-idf.c hal/esp32c3_start.S
 
 $(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC))
 

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -1,26 +1,53 @@
 # SPDX-License-Identifier: Apache-2.0
+CROSS_PREFIX := riscv32-esp-elf-
+include mk/gcc-config.mk
 
 IDF_PATH ?=
 ESP_IDF_LIB ?=
+
 LDSCRIPTS = \
-	$(IDF_PATH)/components/bootloader/subproject/main/ld/esp32c3/bootloader.ld \
+	hal/esp32-c3.ld \
 	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.api.ld \
 	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.ld \
 	$(IDF_PATH)/components/esp_rom/esp32c3/ld/esp32c3.rom.newlib.ld \
 	$(IDF_PATH)/components/soc/esp32c3/ld/esp32c3.peripherals.ld
 
+ifeq ($(RNG),NISTKAT)
+	LIBHAL_SRC = \
+		test/common/nistkatrng.c \
+		test/common/aes.c
+	CPPFLAGS += -Itest/common
+else
+	RNG := NOTRAND
+	LIBHAL_SRC = hal/notrandombytes.c
+endif
+
 LIBHAL_SRC += hal/hal-esp-idf.c
 
-obj/libhal.a: $(call objs,$(LIBHAL_SRC))
+$(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC))
 
 ARCH_FLAGS += -march=rv32imc_zicsr_zifencei 
 
 CPPFLAGS += -DRISCV -DESP32C3
 
-CFLAGS += $(ARCH_FLAGS)
+CFLAGS += \
+	-I$(IDF_PATH)/components/soc/include \
+	-I$(IDF_PATH)/components/soc/esp32c3/include \
+	-I$(IDF_PATH)/components/esp_rom/include \
+	-I$(IDF_PATH)/components/hal/include \
+	-isystem$(IDF_PATH)/components/hal/esp32c3/include \
+	-I$(IDF_PATH)/components/hal/platform_port/include \
+	-I$(IDF_PATH)/components/esp_common/include \
+	-I$(IDF_PATH)/components/esp_rom/include/esp32c3 \
+	-I$(IDF_PATH)/components/esp_hw_support/include \
+	-I$(ESP_IDF_LIB)/esp32c3/bootloader/config \
+	$(ARCH_FLAGS) \
+	-fdata-sections -ffunction-sections \
+	-nostartfiles -Og
 
 # platform specific ldflags
-LDFLAGS += \
+LDLIBS += \
+	$(addprefix -T,$(LDSCRIPTS)) \
 	-lesp_rom -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/esp_rom \
 	-lsoc -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/soc \
 	-lesp_common -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/esp_common \
@@ -31,5 +58,5 @@ LDFLAGS += \
 LDFLAGS += \
 	-nostdlib \
 	-nostartfiles \
-	$(addprefex -T,$(LDSCRIPTS)) \
+	-static \
 	$(ARCH_FLAGS)

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -40,6 +40,7 @@ CFLAGS += \
 	-I$(IDF_PATH)/components/esp_common/include \
 	-I$(IDF_PATH)/components/esp_rom/include/esp32c3 \
 	-I$(IDF_PATH)/components/esp_hw_support/include \
+	-I$(IDF_PATH)/components/riscv/include \
 	-I$(ESP_IDF_LIB)/esp32c3/bootloader/config \
 	$(ARCH_FLAGS) \
 	-fdata-sections -ffunction-sections \

--- a/mk/esp32-c3.mk
+++ b/mk/esp32-c3.mk
@@ -18,8 +18,8 @@ ifeq ($(RNG),NISTKAT)
 		test/common/aes.c
 	CPPFLAGS += -Itest/common
 else
-	RNG := NOTRAND
-	LIBHAL_SRC = hal/notrandombytes.c
+	RNG := HAL
+	LIBHAL_SRC = hal/randombytes.c
 endif
 
 LIBHAL_SRC += hal/hal-esp-idf.c hal/esp32c3_start.S
@@ -40,6 +40,7 @@ CFLAGS += \
 	-I$(IDF_PATH)/components/esp_common/include \
 	-I$(IDF_PATH)/components/esp_rom/include/esp32c3 \
 	-I$(IDF_PATH)/components/esp_hw_support/include \
+	-I$(IDF_PATH)/components/bootloader_support/include \
 	-I$(IDF_PATH)/components/riscv/include \
 	-I$(ESP_IDF_LIB)/esp32c3/bootloader/config \
 	$(ARCH_FLAGS) \
@@ -53,6 +54,7 @@ LDLIBS += \
 	-lsoc -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/soc \
 	-lesp_common -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/esp_common \
 	-lesp_hw_support -L$(ESP_IDF_LIB)/esp32c3/esp-idf/esp_hw_support \
+	-lbootloader_support -L$(ESP_IDF_LIB)/esp32c3/bootloader/esp-idf/bootloader_support \
 	-lhal -L$(ESP_IDF_LIB)/esp32c3/esp-idf/hal \
 	-lg_nano
 

--- a/mk/gcc-config.mk
+++ b/mk/gcc-config.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 # GCC config
 CROSS_PREFIX ?=
 CC := $(CROSS_PREFIX)gcc

--- a/mk/gcc-config.mk
+++ b/mk/gcc-config.mk
@@ -1,0 +1,8 @@
+# GCC config
+CROSS_PREFIX ?=
+CC := $(CROSS_PREFIX)gcc
+CPP := $(CROSS_PREFIX)cpp
+AR := $(CROSS_PREFIX)ar
+LD := $(CC)
+OBJCOPY := $(CROSS_PREFIX)objcopy
+SIZE := $(CROSS_PREFIX)size

--- a/mk/mbed-os.mk
+++ b/mk/mbed-os.mk
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+CROSS_PREFIX := arm-none-eabi-
+include mk/gcc-config.mk
+
 ifeq ($(RNG),NISTKAT)
 	LIBHAL_SRC = \
 		test/common/nistkatrng.c \
@@ -24,8 +27,8 @@ STARTUP_OBJ = $(shell echo "$(STARTUP_SRC)" | sed -E 's~(.*/)(TARGET.*)~$(OBJ_DI
 
 MPS2_DEPS += -I$(MBED_OS_DIR)/Include -I$(MBED_OS_TARGET_DIR)
 
-$(OBJ_DIR)/hal/libhal.a: $(call objs,$(LIBHAL_SRC)) $(STARTUP_OBJ)
-$(OBJ_DIR)/hal/libhal.a: CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
+$(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC)) $(STARTUP_OBJ)
+$(OBJ_DIR)/hal/libpqcphal.a: CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
 
 $(STARTUP_OBJ): $(STARTUP_SRC)
 	@echo "  AS      $@"
@@ -39,4 +42,4 @@ $(LDSCRIPT): 	$(MBED_OS_TARGET_DIR)/TOOLCHAIN_GCC_ARM/MPS2.ld
 
 $(LDSCRIPT): CPPFLAGS += $(MPS2_DEPS) $(if $(RNG)==NISTKAT,-Itest/common)
 
-LINKDEPS += $(LDSCRIPT) $(LIBDEPS)
+LINKDEPS += $(LDSCRIPT)

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,4 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
+CROSS_PREFIX := arm-none-eabi-
+include mk/gcc-config.mk
+
 ifeq ($(RNG),NISTKAT)
 	LIBHAL_SRC = \
 		test/common/nistkatrng.c \
@@ -18,7 +21,7 @@ include $(OPENCM3_DIR)/mk/gcc-rules.mk
 
 LIBHAL_SRC += hal/hal-opencm3.c
 
-$(OBJ_DIR)/hal/libhal.a: $(call objs,$(LIBHAL_SRC))
+$(OBJ_DIR)/hal/libpqcphal.a: $(call objs,$(LIBHAL_SRC))
 
 CFLAGS += $(ARCH_FLAGS)
 
@@ -27,4 +30,4 @@ LDFLAGS += \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 
-LINKDEPS += $(LDSCRIPT) $(LIBDEPS)
+LINKDEPS += $(LDSCRIPT)

--- a/scripts/tests
+++ b/scripts/tests
@@ -116,6 +116,7 @@ class PLATFORM(Enum):
     MPS2_AN500 = 4
     NUCLEO_F207ZG = 5
     MPS2_AN385 = 6
+    ESP32_C3 = 7
 
     def __str__(self):
         return self.name.lower().replace("_", "-")

--- a/scripts/tests
+++ b/scripts/tests
@@ -116,7 +116,6 @@ class PLATFORM(Enum):
     MPS2_AN500 = 4
     NUCLEO_F207ZG = 5
     MPS2_AN385 = 6
-    ESP32_C3 = 7
 
     def __str__(self):
         return self.name.lower().replace("_", "-")

--- a/test/stack.c
+++ b/test/stack.c
@@ -5,39 +5,15 @@
 #include "sendfn.h"
 
 #include <string.h>
-
-#ifndef MAX_STACK_SIZE
-#define MAX_STACK_SIZE hal_get_stack_size()
-#endif
-
-#ifndef STACK_SIZE_INCR
-#define STACK_SIZE_INCR 0x1000
-#endif
+#include <stdio.h>
 
 #define send_stack_usage(S, U) send_unsigned((S), (U))
-
-unsigned int canary_size;
-volatile unsigned char *p;
-unsigned int c;
-uint8_t canary = 0x42;
 
 unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
 unsigned char pk[CRYPTO_PUBLICKEYBYTES];
 unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
 unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
 unsigned int stack_key_gen, stack_encaps, stack_decaps;
-
-#define FILL_STACK()                                                           \
-    p = &a;                                                                      \
-    while (p > &a - canary_size)                                                 \
-        *(p--) = canary;
-#define CHECK_STACK()                                                          \
-    c = canary_size;                                                             \
-    p = &a - canary_size + 1;                                                    \
-    while (*p == canary && p < &a) {                                             \
-        p++;                                                                       \
-        c--;                                                                       \
-    }
 
 static int test_keys(void) {
     // Alice generates a public key


### PR DESCRIPTION
depends on #48 

This PR added `esp32c3` support to the build system
running
```
make PLATFORM=esp32-c3
```
should be able to compile the binary for all tests (test/speed/stack/nistkat).

Then flash to the `esp32c3` device with
```
esptool.py -p <PORT> write_flash 0x0 build/esp32-c3/bin/<bin_name>.bin
```
where `PORT` start with `/dev/tty` and `/dev/cu` on Linux and macOS respectively.

This is not integrated to the `tests` script yet, there will be a separate PR for this.

You can receive serial output from the same device (after resetting the board) - the baud rate is 115200:
```
pyserial-miniterm <PORT> 115200 
```

Building the artifacts for `esp32c3` is included in CI as well.

### UPDATE:
#### Cycle Count

- CLOCK_BENCHMARK = 80MHZ (which is the max clock frequency for flash)
```
keypair cycles
4015868
encaps cycles
3736502
decaps cycles
4492722
```
- CLOCK_FAST = 160 MHZ, will get
```
keypair cycles
5426636
encaps cycles
4846023
decaps cycles
6056913
```

#### Stack Usage
```
keypair stack usage:
3600
encaps stack usage:
3648
decaps stack usage:
3616
```
[//]: # (SPDX-License-Identifier: CC-BY-4.0)
[//]: # (TODO Customize PR template)

[//]: # (See https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository )

<!-- Please give a brief explanation of the purpose of this pull request. -->

<!-- Does this PR resolve any issue?  If so, please reference it using automatic-closing keywords like "Fixes #123." -->

<!-- Any PR adding a new feature is expected to contain a test; the test should be part of CI testing, preferably within the ".github/workflows" directory tree. Please add an explanation to the PR if/when (why) this cannot be done. -->

<!-- Please answer the following questions to help manage version and changes across projects. -->

* [ ] Does this PR change the input/output behaviour of a cryptographic algorithm (i.e., does it change known answer test values)?  (If so, a version bump will be required from *x.y.z* to *x.(y+1).0*.)

<!-- Once your pull request is ready for review and passing continuous integration tests, please convert from a draft PR to a normal PR, and request a review from one of the OQS core team members. -->
